### PR TITLE
Tracking WordPress Manual/Auto Update

### DIFF
--- a/connectors/installer.php
+++ b/connectors/installer.php
@@ -71,10 +71,13 @@ class WP_Stream_Connector_Installer extends WP_Stream_Connector {
 	 * @return array             Action links
 	 */
 	public static function action_links( $links, $record ) {
-		if ( $record->context == 'wordpress' && $record->action == 'updated' ) {
-			$links [ __( 'About', 'stream' ) ] = admin_url( 'about.php?updated' );
-			$version = get_stream_meta( $record->ID, 'wp_version', true );
-			$links [ __( 'View Release Notes', 'stream' ) ] = esc_url( sprintf( 'http://codex.wordpress.org/Version_%s', $version ) );
+		if ( 'wordpress' == $record->context && 'updated' == $record->action ) {
+			global $wp_version;
+			$version = get_stream_meta( $record->ID, 'new_version', true );
+			if ( $version === $wp_version ) {
+				$links[ __( 'About', 'stream' ) ] = admin_url( 'about.php?updated' );
+			}
+			$links[ __( 'View Release Notes', 'stream' ) ] = esc_url( sprintf( 'http://codex.wordpress.org/Version_%s', $version ) );
 		}
 		return $links;
 	}


### PR DESCRIPTION
Resolves #80, @fjarrett please review.

For the reference, specially for the upcoming unit tests, to initiate the auto update process, the following filters/actions is needed:

``` php
add_action('admin_init', 'wp_maybe_auto_update');
add_filter( 'allow_major_auto_core_updates', '__return_true' );
add_filter( 'automatic_updates_is_vcs_checkout', '__return_false' );
delete_option( 'auto_updater.lock' );
```

Plus changing the WP version itself via changing the global `wp_version` or editing the `version.php` file directly.
