### PR TITLE
Remove redundant DOING_AJAX check

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -83,7 +83,7 @@ class WP_Stream {
 		require_once WP_STREAM_INC_DIR . 'feeds.php';
 		add_action( 'init', array( 'WP_Stream_Feeds', 'load' ) );
 
-		if ( is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+		if ( is_admin() ) {
 			require_once WP_STREAM_INC_DIR . 'admin.php';
 			add_action( 'plugins_loaded', array( 'WP_Stream_Admin', 'load' ) );
 		}


### PR DESCRIPTION
DOING_AJAX is always going to be the same as is_admin(), as admin-ajax.php, which defines DOING_AJAX, is loaded in an admin context. 

Given that it's loading admin-facing functionality, it seems more idiomatically proper to only check is_admin().
