### PR TITLE
Add title attribute for summary links @jonathanbardo Please review, resolves #138

### DIFF
--- a/includes/list-table.php
+++ b/includes/list-table.php
@@ -129,9 +129,11 @@ class WP_Stream_List_Table extends WP_List_Table {
 						$item->summary,
 						array(
 							'object_id' => $item->object_id,
-							'context' => $item->context,
-							)
-						);
+							'context'   => $item->context,
+						),
+						null,
+						__( 'View all records for this object', 'stream' )
+					);
 				} else {
 					$out = $item->summary;
 				}
@@ -208,23 +210,21 @@ class WP_Stream_List_Table extends WP_List_Table {
 		return $out;
 	}
 
-	function column_link( $display, $key, $value = null ) {
+	function column_link( $display, $key, $value = null, $title = null ) {
 		$url = admin_url( 'admin.php?page=wp_stream' );
 
-		if ( ! is_array( $key ) ) {
-			$args = array( $key => $value );
-		} else {
-			$args = $key;
-		}
+		$args = ! is_array( $key ) ? array( $key => $value ) : $key;
+
 		foreach ( $args as $k => $v ) {
 			$url = add_query_arg( $k, $v, $url );
 		}
 
 		return sprintf(
-			'<a href="%s">%s</a>',
-			$url,
-			$display
-		); // xss okay
+			'<a href="%s" title="%s">%s</a>',
+			esc_url( $url ),
+			esc_attr( $title ),
+			esc_html( $display )
+		);
 	}
 
 	function filters_form() {


### PR DESCRIPTION
We can't really confidently display the object name here because it could be a lot of different things (post_title, user_name, term_name, etc.)

We also can't really use the context name either because it's label must always be singular, and that's not always the case.

So the safest option is just to use one generic title for all cases.

Lastly, while performing this change I discovered a bug introduced in #134 where the context name was not compat in query strings because it wasn't being sanitized, so queries weren't working correctly (e.g. `context=MainMenu` should be `context=main-menu`).

Fixed in https://github.com/x-team/wp-stream/commit/d1c48ca7445c97b3b30b9d520cbcd839dc1dc2ea
