### PR TITLE
Issue-168 User meta key for live update preference should be prefixed

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -570,7 +570,7 @@ class WP_Stream_Admin {
 	 */
 	public static function live_update( $response, $data ) {
 
-		$enable_update = get_user_meta( get_current_user_id(), 'enable_live_update', true );
+		$enable_update = get_user_meta( get_current_user_id(), 'stream_live_update_records', true );
 		$enable_update = isset( $enable_update ) ? $enable_update : '';
 
 		if ( 'live-update' === $data['wp-stream-heartbeat'] && $enable_update == 'on' ) {
@@ -652,7 +652,7 @@ class WP_Stream_Admin {
 
 		$user = (int) $input['user'];
 
-		$success = update_user_meta( $user, 'enable_live_update', $checked );
+		$success = update_user_meta( $user, 'stream_live_update_records', $checked );
 
 		if ( $success ) {
 			wp_send_json_success( 'Live Updates Enabled' );

--- a/includes/list-table.php
+++ b/includes/list-table.php
@@ -436,8 +436,8 @@ class WP_Stream_List_Table extends WP_List_Table {
 	}
 
 	static function set_live_update_option( $dummy, $option, $value ) {
-		if ( $option == 'enable_live_update' ) {
-			$value = $_POST['enable_live_update'];
+		if ( $option == 'stream_live_update_records' ) {
+			$value = $_POST['stream_live_update_records'];
 			return $value;
 		} else {
 			return $dummy;
@@ -446,7 +446,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 
 	static function live_update_checkbox( $status, $args ) {
 		$user_id = get_current_user_id();
-		$option  = get_user_meta( $user_id, 'enable_live_update', true );
+		$option  = get_user_meta( $user_id, 'stream_live_update_records', true );
 		$value   = isset( $option ) ? $option : 'on';
 		$nonce   = wp_create_nonce( 'stream_live_update_nonce' );
 		ob_start();


### PR DESCRIPTION
Renamed user meta key for live update.  

Fixes https://github.com/x-team/wp-stream/issues/168

cc/ @fjarrett 
