### PR TITLE
issue-252 Plugin incompatibility issue causing missing argument warning

### DIFF
--- a/connectors/users.php
+++ b/connectors/users.php
@@ -248,7 +248,8 @@ class WP_Stream_Connector_Users extends WP_Stream_Connector {
 	 *
 	 * @action wp_login
 	 */
-	public static function callback_wp_login( $user_login, $user ) {
+	public static function callback_wp_login( $user_login ) {
+		$user = get_user_by( 'login', $user_login );
 		if ( self::is_logging_enabled_for_user( $user ) ) {
 			self::log(
 				__( '%s logged in', 'stream' ),


### PR DESCRIPTION
Removed second param in method, and used get_user_by.  

Tested with Clef Plugin.  Pretty Sweet!

Fixes https://github.com/x-team/wp-stream/issues/252
