### PR TITLE
Issue 261: Use post type as the Context name for the Comments connector

### DIFF
--- a/connectors/comments.php
+++ b/connectors/comments.php
@@ -385,7 +385,7 @@ class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 				'stream'
 			),
 			compact( 'user_name', 'new_status', 'old_status', 'post_title', 'post_id', 'user_id' ),
-			$comment->comment_id,
+			$comment->comment_ID,
 			array( $post_type => $new_status )
 		);
 	}


### PR DESCRIPTION
Fixes #261 

![comments actions](https://f.cloud.github.com/assets/2076782/2241252/0edebd88-9cc8-11e3-95e6-fd35497437b4.png)

I have changed context logging for all comments actions except one, which is flooding. This one doesn't need to come up with one post type. My idea is to use explicit context name for this kind of actions, how about `Security`?
