### PR TITLE
Prevent UI from allowing invalid date intervals

### DIFF
--- a/ui/admin.js
+++ b/ui/admin.js
@@ -19,12 +19,12 @@ jQuery(function($){
 			currentDateTo;
 
 		$date_from.change( function() {
-			currentDateFrom = $(this).datepicker( 'getDate' )
+			currentDateFrom = $(this).datepicker( 'getDate' );
 			$date_to.datepicker( 'option', 'minDate', currentDateFrom );
 		});
 
 		$date_to.change( function() {
-			currentDateTo = $(this).datepicker( 'getDate' )
+			currentDateTo = $(this).datepicker( 'getDate' );
 			$date_from.datepicker( 'option', 'maxDate', currentDateTo );
 		});
 	}


### PR DESCRIPTION
Fixes #292.

I chose not to set readonly to the text inputs in the HTML so that
these fields can still work without javascript enabled.

If I were to set readonly to the datepicker inputs at document load and
mimic a clickable input through styling, I would have to override the
WordPress admin’ input[readonly]’ style with
    background-color: #fff;

But this assumes that clickable inputs will always have a background
colour of white. On the other hand, it would be a bit of a safer way to
prevent input.
