### PR TITLE
Issue 364: Autocomplete not working correctly in Exclude Authors & Roles field

### DIFF
--- a/ui/admin.js
+++ b/ui/admin.js
@@ -197,7 +197,7 @@ jQuery(function($){
 					};
 				},
 				results: function (response) {
-					var roles  = [];
+					var roles  = [],
 						answer = [];
 
 					roles = $.grep(


### PR DESCRIPTION
Fix #364 

![filtered roles](https://f.cloud.github.com/assets/2076782/2509678/1be1fd7c-b3f9-11e3-907a-679df3a67f44.png)
