### PR TITLE
Always use placeholders in prepared SQL statements

### DIFF
--- a/includes/query.php
+++ b/includes/query.php
@@ -136,14 +136,14 @@ class WP_Stream_Query {
 		if ( $args['record__in'] ) {
 			$record__in = implode( ',', array_filter( (array) $args['record__in'], 'is_numeric' ) );
 			if ( $record__in ) {
-				$where .= " AND $wpdb->stream.ID IN ($record__in)";
+				$where .= $wpdb->prepare( " AND $wpdb->stream.ID IN (%s)", $record__in );
 			}
 		}
 
 		if ( $args['record__not_in'] ) {
 			$record__not_in = implode( ',', array_filter( (array) $args['record__not_in'], 'is_numeric' ) );
 			if ( strlen( $record__not_in ) ) {
-				$where .= " AND $wpdb->stream.ID NOT IN ($record__not_in)";
+				$where .= $wpdb->prepare( " AND $wpdb->stream.ID NOT IN (%s)", $record__not_in );
 			}
 		}
 
@@ -154,28 +154,28 @@ class WP_Stream_Query {
 		if ( $args['record_parent__in'] ) {
 			$record_parent__in = implode( ',', array_filter( (array) $args['record_parent__in'], 'is_numeric' ) );
 			if ( strlen( $record_parent__in ) ) {
-				$where .= " AND $wpdb->stream.parent IN ($record_parent__in)";
+				$where .= $wpdb->prepare( " AND $wpdb->stream.parent IN (%s)", $record_parent__in );
 			}
 		}
 
 		if ( $args['record_parent__not_in'] ) {
 			$record_parent__not_in = implode( ',', array_filter( (array) $args['record_parent__not_in'], 'is_numeric' ) );
 			if ( strlen( $record_parent__not_in ) ) {
-				$where .= " AND $wpdb->stream.parent NOT IN ($record_parent__not_in)";
+				$where .= $wpdb->prepare( " AND $wpdb->stream.parent NOT IN (%s)", $record_parent__not_in );
 			}
 		}
 
 		if ( $args[ 'author__in' ] ) {
 			$author__in = implode( ',', array_filter( (array)$args[ 'author__in' ], 'is_numeric' ) );
 			if ( $author__in ) {
-				$where .= " AND $wpdb->stream.author IN ($author__in)";
+				$where .= $wpdb->prepare( " AND $wpdb->stream.author IN (%s)", $author__in );
 			}
 		}
 
 		if ( $args[ 'author__not_in' ] ) {
 			$author__not_in = implode( ',', array_filter( (array)$args[ 'author__not_in' ], 'is_numeric' ) );
 			if ( strlen( $author__not_in ) ) {
-				$where .= " AND $wpdb->stream.author NOT IN ($author__not_in)";
+				$where .= $wpdb->prepare( " AND $wpdb->stream.author NOT IN (%s)", $author__not_in );
 			}
 		}
 		if ( $args[ 'ip__in' ] ) {


### PR DESCRIPTION
Fixes #354 

Originally, I was just going to remove the prepare statement altogether (see https://github.com/x-team/wp-stream/commit/e4155a9d043b089b943edf507e685a105b24ad00).

Then I decided to just keep the prepare and enter a placeholder (see https://github.com/x-team/wp-stream/commit/941ea29ebc95cf4de200b383ef4a647765110950).

Either way is justifiable I think, just a matter of preference and preparing just brings another layer of comfort for the paranoid.
