### PR TITLE
Issue #357: use printf instead of echo sprintf

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -340,7 +340,7 @@ class WP_Stream_Admin {
 		self::$list_table->prepare_items();
 
 		echo '<div class="wrap">';
-		echo sprintf( '<h2>%s</h2>', __( 'Stream Records', 'stream' ) ); // xss ok
+		printf( '<h2>%s</h2>', __( 'Stream Records', 'stream' ) ); // xss ok
 		self::$list_table->display();
 		echo '</div>';
 	}

--- a/includes/list-table.php
+++ b/includes/list-table.php
@@ -517,7 +517,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 		$filters_string .= sprintf( '<input type="submit" id="record-query-submit" class="button" value="%s">', __( 'Filter', 'stream' ) );
 		$url = admin_url( WP_Stream_Admin::ADMIN_PARENT_PAGE );
 
-		echo sprintf( '<div class="alignleft actions">%s</div>', $filters_string ); // xss ok
+		printf( '<div class="alignleft actions">%s</div>', $filters_string ); // xss ok
 	}
 
 	function filter_select( $name, $title, $items, $ajax ) {
@@ -590,7 +590,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 				<option></option>
 				<option value="custom" <?php selected( 'custom' === $date_predefined ); ?>><?php esc_attr_e( 'Custom', 'stream' ) ?></option>
 				<?php foreach ( $date_interval->intervals as $key => $interval ) {
-					echo sprintf(
+					printf(
 						'<option value="%s" data-from="%s" data-to="%s" %s>%s</option>',
 						esc_attr( $key ),
 						esc_attr( $interval['start']->format( 'Y/m/d' ) ),


### PR DESCRIPTION
Replaced instances of `echo sprintf` with `printf` for the sake of simplicity and brevity.

Fixes #357 
