### PR TITLE
Datepicker Icon Height is too large

### DIFF
--- a/ui/datepicker.css
+++ b/ui/datepicker.css
@@ -61,6 +61,7 @@
 .stream-datepicker.ui-datepicker .ui-datepicker-next-hover,
 .stream-datepicker.ui-datepicker .ui-datepicker-next,
 .stream-datepicker.ui-datepicker .ui-datepicker-prev {
+	height: 1em;
 	top: .9em;
 	border:none;
 }


### PR DESCRIPTION
fixes https://github.com/x-team/wp-stream/issues/372

cc/ @fjarrett 
