### PR TITLE
Issue 351: PHP 5.3.3 compatibility issue with filter constant

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -18,7 +18,6 @@ class WP_Stream_Filter_Input {
 		FILTER_SANITIZE_NUMBER_FLOAT       => 'floatval',
 		FILTER_SANITIZE_NUMBER_INT         => 'intval',
 		FILTER_SANITIZE_SPECIAL_CHARS      => 'htmlspecialchars',
-		FILTER_SANITIZE_FULL_SPECIAL_CHARS => 'htmlspecialchars',
 		FILTER_SANITIZE_STRING             => 'sanitize_text_field',
 		FILTER_SANITIZE_URL                => 'esc_url_raw',
 		// Other


### PR DESCRIPTION
Fix #351 

@fjarrett I just removed it. It's not the most useful one: http://pl1.php.net/manual/en/filter.filters.sanitize.php

I'm not sure if that's reasonable to copy `filter_var` all the way. I'm actually not into those constants thing at all, we could provide an alternative with much better API.
