### PR TITLE
Pipe Character for Row Actions Issue 402 Fix

### DIFF
--- a/includes/list-table.php
+++ b/includes/list-table.php
@@ -323,35 +323,24 @@ class WP_Stream_List_Table extends WP_List_Table {
 			$out .= '<div class="row-actions">';
 		}
 
-		if ( $action_links ) {
-
-			$links = array();
-			$i     = 0;
+		$links = array();
+		if ( $action_links && is_array( $action_links ) ) {
 			foreach ( $action_links as $al_title => $al_href ) {
-				$i ++;
 				$links[] = sprintf(
-					'<span><a href="%s" class="action-link">%s</a>%s</span>',
+					'<span><a href="%s" class="action-link">%s</a></span>',
 					$al_href,
-					$al_title,
-					( count( $action_links ) === $i ) ? null : ' | '
+					$al_title
 				);
 			}
-			$out .= implode( '', $links );
-		}
-
-		if ( $action_links && $custom_links ) {
-			$out .= ' | ';
 		}
 
 		if ( $custom_links && is_array( $custom_links ) ) {
-			$last_link = end( $custom_links );
 			foreach ( $custom_links as $key => $link ) {
-				$out .= $link;
-				if ( $key !== $last_link ) {
-					$out .= ' | ';
-				}
+				$links[] = $link;
 			}
 		}
+
+		$out .= implode( ' | ', $links );
 
 		if ( $action_links || $custom_links ) {
 			$out .= '</div>';


### PR DESCRIPTION
implode logic added for all the Row Action Links.
Fixes #402
