### PR TITLE
Hides the blogs connector unless in Network Admin

### DIFF
--- a/connectors/blogs.php
+++ b/connectors/blogs.php
@@ -59,7 +59,7 @@ class WP_Stream_Connector_Blogs extends WP_Stream_Connector {
 	 */
 	public static function get_context_labels() {
 		$labels = array();
-		if ( is_multisite() ) {
+		if ( is_multisite() && ! wp_is_large_network() ) {
 			$blogs = wp_get_sites();
 			foreach ( $blogs as $blog ) {
 				$blog_details   = get_blog_details( $blog['blog_id'] );

--- a/connectors/settings.php
+++ b/connectors/settings.php
@@ -112,7 +112,7 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 	 * @return array Context label translations
 	 */
 	public static function get_context_labels() {
-		return array(
+		$context_labels = array(
 			'settings'           => __( 'Settings', 'stream' ),
 			'general'            => __( 'General', 'stream' ),
 			'writing'            => __( 'Writing', 'stream' ),
@@ -122,11 +122,21 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 			'permalink'          => __( 'Permalinks', 'stream' ),
 			'network'            => __( 'Network', 'stream' ),
 			'wp_stream'          => __( 'Stream', 'stream' ),
-			'wp_stream_network'  => __( 'Stream Network', 'stream' ),
-			'wp_stream_defaults' => __( 'Stream Defaults', 'stream' ),
 			'custom_background ' => __( 'Custom Background', 'stream' ),
 			'custom_header'      => __( 'Custom Header', 'stream' ),
 		);
+
+		if ( is_network_admin() ) {
+			$context_labels = array_merge(
+				$context_labels,
+				array(
+					'wp_stream_network'  => __( 'Stream Network', 'stream' ),
+					'wp_stream_defaults' => __( 'Stream Defaults', 'stream' ),
+				)
+			);
+		}
+
+		return $context_labels;
 	}
 
 	/**

--- a/includes/connectors.php
+++ b/includes/connectors.php
@@ -69,8 +69,8 @@ class WP_Stream_Connectors {
 		 */
 		self::$connectors = apply_filters( 'wp_stream_connectors', $classes );
 
-		foreach ( $classes as $class ) {
-			self::$term_labels['stream_connector'][ $class::$name ] = $class::get_label();
+		foreach ( self::$connectors as $connector ) {
+			self::$term_labels['stream_connector'][ $connector::$name ] = $connector::get_label();
 		}
 
 		// Get excluded connectors

--- a/includes/network.php
+++ b/includes/network.php
@@ -40,6 +40,7 @@ class WP_Stream_Network {
 		add_filter( 'wp_stream_list_table_screen_id', array( $this, 'list_table_screen_id' ) );
 		add_filter( 'wp_stream_query_args', array( __CLASS__, 'set_network_option_value' ) );
 		add_filter( 'wp_stream_list_table_columns', array( $this, 'network_admin_columns' ) );
+		add_filter( 'wp_stream_connectors', array( $this, 'hide_blogs_connector' ) );
 	}
 
 	/**
@@ -406,7 +407,7 @@ class WP_Stream_Network {
 	 * @return array
 	 */
 	function list_table_filters( $filters ) {
-		if ( is_network_admin() ) {
+		if ( is_network_admin() && ! wp_is_large_network() ) {
 			$blogs = array();
 
 			// display network blog as the first option
@@ -504,4 +505,17 @@ class WP_Stream_Network {
 		return $columns;
 	}
 
+	/**
+	 * Prevent the Blogs connector from loading when not in network_admin
+	 *
+	 * @param $args
+	 *
+	 * @return mixed
+	 */
+	function hide_blogs_connector( $connectors ) {
+		if ( ! is_network_admin() ) {
+			return array_diff( $connectors, array( 'WP_Stream_Connector_Blogs' ) );
+		}
+		return $connectors;
+	}
 }


### PR DESCRIPTION
This fixes #433 - a security issue where sites were being populated in the context dropdown menu, even if the user didn't have access to those sites.

It also prevents some network features from loading if `wp_is_large_network()` is true. By default, this is at 10,000 sites - but if we feel that this is too much for Stream we could make it less.
