### PR TITLE
Show error if updating on non-connected site

### DIFF
--- a/includes/extensions.php
+++ b/includes/extensions.php
@@ -185,7 +185,7 @@ class WP_Stream_Extensions {
 			return $false;
 		}
 
-		if (  $this->verify_membership() ) {
+		if ( ! $this->verify_membership() ) {
 			wp_die( __( 'Please connect your site to stream premium to enable updates', 'stream' ), 'Stream Update Error', array( 'response' => 200, 'back_link' => true ) );
 		}
 


### PR DESCRIPTION
- Adds filter to upgrader_pre_download which runs before update download is attempted
- If updating a stream extension and no license exists send wp_die message
- Fixes #459
