### PR TITLE
Precautious check for availability of $wp_roles

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -745,18 +745,23 @@ class WP_Stream_Admin {
 	 * @return array
 	 */
 	public static function _filter_user_caps( $allcaps, $caps, $args, $user = null ) {
-		$user = is_a( $user, 'WP_User' ) ? $user : wp_get_current_user();
+		$user  = is_a( $user, 'WP_User' ) ? $user : wp_get_current_user();
+		$roles = $user->roles;
+
+		// Fix for empty user->roles arrays, eg: When NewRelic integration in W3-Total-Cache is enabled
 		// @see
 		// https://github.com/WordPress/WordPress/blob/c67c9565f1495255807069fdb39dac914046b1a0/wp-includes/capabilities.php#L758
-		$roles = array_unique(
-			array_merge(
-				$user->roles,
-				array_filter(
-					array_keys( $user->caps ),
-					array( $GLOBALS['wp_roles'], 'is_role' )
+		if ( isset( $GLOBALS['wp_roles'] ) && empty( $roles ) ) {
+			$roles = array_unique(
+				array_merge(
+					$user->roles,
+					array_filter(
+						array_keys( $user->caps ),
+						array( $GLOBALS['wp_roles'], 'is_role' )
+					)
 				)
-			)
-		);
+			);
+		}
 
 		foreach ( $caps as $cap ) {
 			if ( self::VIEW_CAP === $cap ) {


### PR DESCRIPTION
Disables merging with user->caps if wp_roles is not available yet
Ref: http://wordpress.org/support/topic/cant-access-wp-admin-49?replies=2#post-5510667
