### PR TITLE
Ignore PHP CodeSniffer Warning on WP_Stream_Filter_Input::is_regex

### DIFF
--- a/includes/filter-input.php
+++ b/includes/filter-input.php
@@ -101,7 +101,9 @@ class WP_Stream_Filter_Input {
 	}
 
 	public static function is_regex( $var ) {
+		// @codingStandardsIgnoreStart
 		$test = @preg_match( $var, '' );
+		// @codingStandardsIgnoreEnd
 
 		return $test !== false;
 	}


### PR DESCRIPTION
I was looking at this file and there was a CodeSniffer Warning popping when I tried to save, after some search I found that using these comments would stop this warning.

Is it good to merge to `master`? @shadyvb
