### PR TITLE
Add filterable frontend indicator method

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -282,10 +282,10 @@ class WP_Stream {
 		 *
 		 * @return string $comment The content of the HTML comment
 		 */
-		$comment = apply_filters( 'wp_stream_frontend_indicator', $comment ); // xss ok
+		$comment = apply_filters( 'wp_stream_frontend_indicator', $comment );
 
 		if ( ! empty( $comment ) ) {
-			echo sprintf( "<!-- %s -->\n", esc_html( $comment ) );
+			echo sprintf( "<!-- %s -->\n", esc_html( $comment ) ); // xss ok
 		}
 
 		return;


### PR DESCRIPTION
Resolves #507 

![screen shot 2014-05-06 at 3 37 29 pm](https://cloud.githubusercontent.com/assets/522158/2895319/4cc2cdc8-d55e-11e3-9224-6b83f19a7d2c.png)

Can be easily removed, if desired, like so:

``` php
add_filter( 'wp_stream_frontend_indicator', function() { return false; } );
```

@lukecarbis Please review
