### PR TITLE
Hardcode connectors' filenames

### DIFF
--- a/includes/connectors.php
+++ b/includes/connectors.php
@@ -51,8 +51,8 @@ class WP_Stream_Connectors {
 		$classes = array();
 		foreach ( $connectors as $connector ) {
 			include_once WP_STREAM_DIR . '/connectors/' . $connector .'.php';
-			$class      = "WP_Stream_Connector_$connector";
-			$classes[]  = $class;
+			$class     = "WP_Stream_Connector_$connector";
+			$classes[] = $class;
 		}
 
 		$exclude_all_connector = false;


### PR DESCRIPTION
.. as they don't change often and is waste of resources to loop on then on
each run, also to maintain interoperability #517
