### PR TITLE
Change priority of connectors load to be after widgets_init

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -93,7 +93,7 @@ class WP_Stream {
 
 		// Load connectors
 		require_once WP_STREAM_INC_DIR . 'connectors.php';
-		add_action( 'init', array( 'WP_Stream_Connectors', 'load' ), 2 ); // Just after widgets_init at 1
+		add_action( 'init', array( 'WP_Stream_Connectors', 'load' ), 9 );
 
 		// Load query class
 		require_once WP_STREAM_INC_DIR . 'query.php';

--- a/tests/tests/test-stream.php
+++ b/tests/tests/test-stream.php
@@ -21,7 +21,7 @@ class Test_WP_Stream extends WP_StreamTestCase {
 		$actions_tests = array(
 			array( 'init', 'WP_Stream_Settings', 'load' ),
 			array( 'plugins_loaded', 'WP_Stream_Log', 'load' ),
-			array( 'init', 'WP_Stream_Connectors', 'load', 2 ), // Just after widgets_init at 1
+			array( 'init', 'WP_Stream_Connectors', 'load', 9 ),
 		);
 
 		$this->do_action_validation( $actions_tests );


### PR DESCRIPTION
Fixes #531

The problem was that you can't call `global $wp_registered_sidebars` until the `init` hook has fired with a priority of 1, which is when `wigets_init` happens. See the special note about `widgets_init` in the [Codex Action Reference](http://codex.wordpress.org/Plugin_API/Action_Reference).

So by loading connectors on `init` with a priority of 9 we are able to get the sidebar names correctly and also prevent regression on #501 because we only miss the user login/logout when using `init` with a priority 10.

I think it's better to fire as close to the default priority as we can rather than as far away from it as we can, just in case other plugins (or core) introduce globals on lower priorities that Stream would need.

No upgrade routine is needed for this as all previous records will now query the `get_context_labels` method successfully. MVC approach FTW!
