### PR TITLE
Remove duplicate call to install() method

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -71,8 +71,11 @@ class WP_Stream {
 		require_once WP_STREAM_INC_DIR . 'db.php';
 		$this->db = new WP_Stream_DB;
 
-		// Check DB and add message if not present
+		// Check DB and display an admin notice if there are tables missing
 		add_action( 'init', array( $this, 'verify_database_present' ) );
+
+		// Install the plugin
+		add_action( 'wp_stream_install', array( __CLASS__, 'install' ) );
 
 		// Load languages
 		add_action( 'plugins_loaded', array( __CLASS__, 'i18n' ) );
@@ -172,18 +175,18 @@ class WP_Stream {
 	 * @return void
 	 */
 	public function verify_database_present() {
-		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-			require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
-		}
-
 		/**
-		 * Filter will halt verify_database_present() and install() if set to true
+		 * Filter will halt install() if set to true
 		 *
 		 * @param  bool
 		 * @return bool
 		 */
 		if ( apply_filters( 'wp_stream_no_tables', false ) ) {
 			return;
+		}
+
+		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+			require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 		}
 
 		global $wpdb;
@@ -218,8 +221,8 @@ class WP_Stream {
 			$uninstall_message = sprintf( __( 'Please <a href="%s">uninstall</a> the Stream plugin and activate it again.', 'stream' ), admin_url( 'plugins.php#stream' ) );
 		}
 
-		// Check upgrade routine
-		self::install();
+		// Install the plugin
+		do_action( 'wp_stream_install' );
 
 		if ( ! empty( $database_message ) ) {
 			self::notice( $database_message );


### PR DESCRIPTION
Resolves #528 

This removes a second call of `install()` that is already handled earlier by the `verify_database_present()` method.

Also removes duplicate use of the `wp_stream_no_tables` filter in `install()` that is also handled beforehand by `verify_database_present()`.

I've tested in single site and multisite. Fresh installs and DB upgrade routines are working in both.

@shadyvb @lukecarbis Please review
