### PR TITLE
Use default textdomain where possible

### DIFF
--- a/connectors/blogs.php
+++ b/connectors/blogs.php
@@ -3,13 +3,14 @@
 class WP_Stream_Connector_Blogs extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
+	 *
 	 * @var string
 	 */
 	public static $name = 'blogs';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 * @var array
 	 */
 	public static $actions = array(
@@ -30,12 +31,12 @@ class WP_Stream_Connector_Blogs extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Sites', 'stream' );
+		return __( 'Sites', 'default' );
 	}
 
 	/**
@@ -79,12 +80,12 @@ class WP_Stream_Connector_Blogs extends WP_Stream_Connector {
 	 * @return array             Action links
 	 */
 	public static function action_links( $links, $record ) {
-		$links [ __( 'Site Admin', 'stream' ) ] = get_admin_url( $record->object_id );
+		$links [ __( 'Site Admin', 'default' ) ] = get_admin_url( $record->object_id );
 		if ( $record->object_id ) {
 			$site_admin_link = get_admin_url( $record->object_id );
 
 			if ( $site_admin_link ) {
-				$links [ __( 'Site Admin', 'stream' ) ] = $site_admin_link;
+				$links [ __( 'Site Admin', 'default' ) ] = $site_admin_link;
 			}
 
 			$site_settings_link = add_query_arg(

--- a/connectors/comments.php
+++ b/connectors/comments.php
@@ -3,14 +3,14 @@
 class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'comments';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -28,12 +28,12 @@ class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Comments', 'stream' );
+		return __( 'Comments', 'default' );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 	 */
 	public static function get_context_labels() {
 		return array(
-			'comments' => __( 'Comments', 'stream' ),
+			'comments' => __( 'Comments', 'default' ),
 		);
 	}
 
@@ -83,7 +83,7 @@ class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 				$del_nonce     = wp_create_nonce( "delete-comment_$comment->comment_ID" );
 				$approve_nonce = wp_create_nonce( "approve-comment_$comment->comment_ID" );
 
-				$links[ __( 'Edit', 'stream' ) ] = admin_url( "comment.php?action=editcomment&c=$comment->comment_ID" );
+				$links[ __( 'Edit', 'default' ) ] = admin_url( "comment.php?action=editcomment&c=$comment->comment_ID" );
 
 				if ( 1 === $comment->comment_approved ) {
 					$links[ __( 'Unapprove', 'stream' ) ] = admin_url(

--- a/connectors/editor.php
+++ b/connectors/editor.php
@@ -3,21 +3,21 @@
 class WP_Stream_Connector_Editor extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'editor';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
 	public static $actions = array();
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -35,9 +35,9 @@ class WP_Stream_Connector_Editor extends WP_Stream_Connector {
 	}
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
 		return __( 'Theme Editor', 'stream' );

--- a/connectors/installer.php
+++ b/connectors/installer.php
@@ -3,14 +3,14 @@
 class WP_Stream_Connector_Installer extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Context slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'installer';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -27,9 +27,9 @@ class WP_Stream_Connector_Installer extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
 		return __( 'Installer', 'stream' );
@@ -58,9 +58,9 @@ class WP_Stream_Connector_Installer extends WP_Stream_Connector {
 	 */
 	public static function get_context_labels() {
 		return array(
-			'plugins'   => __( 'Plugins', 'stream' ),
-			'themes'    => __( 'Themes', 'stream' ),
-			'wordpress' => __( 'WordPress', 'stream' ),
+			'plugins'   => __( 'Plugins', 'default' ),
+			'themes'    => __( 'Themes', 'default' ),
+			'wordpress' => __( 'WordPress', 'default' ),
 		);
 	}
 

--- a/connectors/media.php
+++ b/connectors/media.php
@@ -3,14 +3,14 @@
 class WP_Stream_Connector_Media extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'media';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -23,12 +23,12 @@ class WP_Stream_Connector_Media extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Media', 'stream' );
+		return __( 'Media', 'default' );
 	}
 
 	/**
@@ -56,15 +56,15 @@ class WP_Stream_Connector_Media extends WP_Stream_Connector {
 	 */
 	public static function get_context_labels() {
 		return array(
-			'image'       => __( 'Image', 'stream' ),
-			'audio'       => __( 'Audio', 'stream' ),
-			'video'       => __( 'Video', 'stream' ),
+			'image'       => __( 'Image', 'default' ),
+			'audio'       => __( 'Audio', 'default' ),
+			'video'       => __( 'Video', 'default' ),
 			'document'    => __( 'Document', 'stream' ),
 			'spreadsheet' => __( 'Spreadsheet', 'stream' ),
 			'interactive' => __( 'Interactive', 'stream' ),
-			'text'        => __( 'Text', 'stream' ),
-			'archive'     => __( 'Archive', 'stream' ),
-			'code'        => __( 'Code', 'stream' ),
+			'text'        => __( 'Text', 'default' ),
+			'archive'     => __( 'Archive', 'default' ),
+			'code'        => __( 'Code', 'default' ),
 		);
 	}
 
@@ -102,10 +102,10 @@ class WP_Stream_Connector_Media extends WP_Stream_Connector {
 	public static function action_links( $links, $record ) {
 		if ( $record->object_id ) {
 			if ( $link = get_edit_post_link( $record->object_id ) ) {
-				$links[ __( 'Edit Media', 'stream' ) ] = $link;
+				$links[ __( 'Edit Media', 'default' ) ] = $link;
 			}
 			if ( $link = get_permalink( $record->object_id ) ) {
-				$links[ __( 'View', 'stream' ) ] = $link;
+				$links[ __( 'View', 'default' ) ] = $link;
 			}
 		}
 

--- a/connectors/menus.php
+++ b/connectors/menus.php
@@ -3,14 +3,14 @@
 class WP_Stream_Connector_Menus extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'menus';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -21,12 +21,12 @@ class WP_Stream_Connector_Menus extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Menus', 'stream' );
+		return __( 'Menus', 'default' );
 	}
 
 	/**

--- a/connectors/posts.php
+++ b/connectors/posts.php
@@ -3,14 +3,14 @@
 class WP_Stream_Connector_Posts extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'posts';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -20,12 +20,12 @@ class WP_Stream_Connector_Posts extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Posts', 'stream' );
+		return __( 'Posts', 'default' );
 	}
 
 	/**
@@ -230,7 +230,7 @@ class WP_Stream_Connector_Posts extends WP_Stream_Connector {
 	 * @return  string  Post type label
 	 */
 	private static function get_post_type_name( $post_type_slug ) {
-		$name = __( 'Post', 'stream' ); // Default
+		$name = __( 'Post', 'default' ); // Default
 
 		if ( post_type_exists( $post_type_slug ) ) {
 			$post_type = get_post_type_object( $post_type_slug );

--- a/connectors/settings.php
+++ b/connectors/settings.php
@@ -5,14 +5,14 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 	const HIGHLIGHT_FIELD_URL_HASH_PREFIX = 'wp-stream-highlight:';
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'settings';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -92,7 +92,7 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 	 * @return string Translated context label
 	 */
 	public static function get_label() {
-		return __( 'Settings', 'stream' );
+		return __( 'Settings', 'default' );
 	}
 
 	/**
@@ -113,17 +113,17 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 	 */
 	public static function get_context_labels() {
 		$context_labels = array(
-			'settings'           => __( 'Settings', 'stream' ),
-			'general'            => __( 'General', 'stream' ),
-			'writing'            => __( 'Writing', 'stream' ),
-			'reading'            => __( 'Reading', 'stream' ),
-			'discussion'         => __( 'Discussion', 'stream' ),
-			'media'              => __( 'Media', 'stream' ),
-			'permalink'          => __( 'Permalinks', 'stream' ),
-			'network'            => __( 'Network', 'stream' ),
+			'settings'           => __( 'Settings', 'default' ),
+			'general'            => __( 'General', 'default' ),
+			'writing'            => __( 'Writing', 'default' ),
+			'reading'            => __( 'Reading', 'default' ),
+			'discussion'         => __( 'Discussion', 'default' ),
+			'media'              => __( 'Media', 'default' ),
+			'permalink'          => __( 'Permalinks', 'default' ),
+			'network'            => __( 'Network', 'default' ),
 			'wp_stream'          => __( 'Stream', 'stream' ),
-			'custom_background ' => __( 'Custom Background', 'stream' ),
-			'custom_header'      => __( 'Custom Header', 'stream' ),
+			'custom_background ' => __( 'Custom Background', 'default' ),
+			'custom_header'      => __( 'Custom Header', 'default' ),
 		);
 
 		if ( is_network_admin() ) {
@@ -200,95 +200,95 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 	public static function get_field_label( $field_key ) {
 		$labels = array(
 			// General
-			'blogname'                      => __( 'Site Title', 'stream' ),
-			'blogdescription'               => __( 'Tagline', 'stream' ),
-			'siteurl'                       => __( 'WordPress Address (URL)', 'stream' ),
-			'home'                          => __( 'Site Address (URL)', 'stream' ),
-			'admin_email'                   => __( 'E-mail Address', 'stream' ),
-			'users_can_register'            => __( 'Membership', 'stream' ),
-			'default_role'                  => __( 'New User Default Role', 'stream' ),
-			'timezone_string'               => __( 'Timezone', 'stream' ),
-			'date_format'                   => __( 'Date Format', 'stream' ),
-			'time_format'                   => __( 'Time Format', 'stream' ),
-			'start_of_week'                 => __( 'Week Starts On', 'stream' ),
+			'blogname'                      => __( 'Site Title', 'default' ),
+			'blogdescription'               => __( 'Tagline', 'default' ),
+			'siteurl'                       => __( 'WordPress Address (URL)', 'default' ),
+			'home'                          => __( 'Site Address (URL)', 'default' ),
+			'admin_email'                   => __( 'E-mail Address', 'default' ),
+			'users_can_register'            => __( 'Membership', 'default' ),
+			'default_role'                  => __( 'New User Default Role', 'default' ),
+			'timezone_string'               => __( 'Timezone', 'default' ),
+			'date_format'                   => __( 'Date Format', 'default' ),
+			'time_format'                   => __( 'Time Format', 'default' ),
+			'start_of_week'                 => __( 'Week Starts On', 'default' ),
 			// Writing
-			'use_smilies'                   => __( 'Formatting', 'stream' ),
-			'use_balanceTags'               => __( 'Formatting', 'stream' ),
-			'default_category'              => __( 'Default Post Category', 'stream' ),
-			'default_post_format'           => __( 'Default Post Format', 'stream' ),
-			'mailserver_url'                => __( 'Mail Server Address', 'stream' ),
-			'mailserver_login'              => __( 'Mail Server Login Name', 'stream' ),
-			'mailserver_pass'               => __( 'Mail Server Password', 'stream' ),
-			'default_email_category'        => __( 'Default Mail Category', 'stream' ),
-			'ping_sites'                    => __( 'Update Services', 'stream' ),
+			'use_smilies'                   => __( 'Formatting', 'default' ),
+			'use_balanceTags'               => __( 'Formatting', 'default' ),
+			'default_category'              => __( 'Default Post Category', 'default' ),
+			'default_post_format'           => __( 'Default Post Format', 'default' ),
+			'mailserver_url'                => __( 'Mail Server', 'default' ),
+			'mailserver_login'              => __( 'Login Name', 'default' ),
+			'mailserver_pass'               => __( 'Password', 'default' ),
+			'default_email_category'        => __( 'Default Mail Category', 'default' ),
+			'ping_sites'                    => __( 'Update Services', 'default' ),
 			// Reading
-			'show_on_front'                 => __( 'Front page displays', 'stream' ),
-			'page_on_front'                 => __( 'Front page displays', 'stream' ),
-			'page_for_posts'                => __( 'Front page displays', 'stream' ),
-			'posts_per_page'                => __( 'Blog pages show at most', 'stream' ),
-			'posts_per_rss'                 => __( 'Syndication feeds show the most recent', 'stream' ),
-			'rss_use_excerpt'               => __( 'For each article in a feed, show', 'stream' ),
-			'blog_public'                   => __( 'Search Engine Visibility', 'stream' ),
+			'show_on_front'                 => __( 'Front page displays', 'default' ),
+			'page_on_front'                 => __( 'Front page displays', 'default' ),
+			'page_for_posts'                => __( 'Front page displays', 'default' ),
+			'posts_per_page'                => __( 'Blog pages show at most', 'default' ),
+			'posts_per_rss'                 => __( 'Syndication feeds show the most recent', 'default' ),
+			'rss_use_excerpt'               => __( 'For each article in a feed, show', 'default' ),
+			'blog_public'                   => __( 'Search Engine Visibility', 'default' ),
 			// Discussion
-			'default_pingback_flag'         => __( 'Default article settings', 'stream' ),
-			'default_ping_status'           => __( 'Default article settings', 'stream' ),
-			'default_comment_status'        => __( 'Default article settings', 'stream' ),
-			'require_name_email'            => __( 'Other comment settings', 'stream' ),
-			'comment_registration'          => __( 'Other comment settings', 'stream' ),
-			'close_comments_for_old_posts'  => __( 'Other comment settings', 'stream' ),
-			'close_comments_days_old'       => __( 'Other comment settings', 'stream' ),
-			'thread_comments'               => __( 'Other comment settings', 'stream' ),
-			'thread_comments_depth'         => __( 'Other comment settings', 'stream' ),
-			'page_comments'                 => __( 'Other comment settings', 'stream' ),
-			'comments_per_page'             => __( 'Other comment settings', 'stream' ),
-			'default_comments_page'         => __( 'Other comment settings', 'stream' ),
-			'comment_order'                 => __( 'Other comment settings', 'stream' ),
-			'comments_notify'               => __( 'E-mail me whenever', 'stream' ),
-			'moderation_notify'             => __( 'E-mail me whenever', 'stream' ),
-			'comment_moderation'            => __( 'Before a comment appears', 'stream' ),
-			'comment_whitelist'             => __( 'Before a comment appears', 'stream' ),
-			'comment_max_links'             => __( 'Comment Moderation', 'stream' ),
-			'moderation_keys'               => __( 'Comment Moderation', 'stream' ),
-			'blacklist_keys'                => __( 'Comment Blacklist', 'stream' ),
-			'show_avatars'                  => __( 'Avatar Display', 'stream' ),
-			'avatar_rating'                 => __( 'Avatar Maximum Rating', 'stream' ),
-			'avatar_default'                => __( 'Default Avatar', 'stream' ),
+			'default_pingback_flag'         => __( 'Default article settings', 'default' ),
+			'default_ping_status'           => __( 'Default article settings', 'default' ),
+			'default_comment_status'        => __( 'Default article settings', 'default' ),
+			'require_name_email'            => __( 'Other comment settings', 'default' ),
+			'comment_registration'          => __( 'Other comment settings', 'default' ),
+			'close_comments_for_old_posts'  => __( 'Other comment settings', 'default' ),
+			'close_comments_days_old'       => __( 'Other comment settings', 'default' ),
+			'thread_comments'               => __( 'Other comment settings', 'default' ),
+			'thread_comments_depth'         => __( 'Other comment settings', 'default' ),
+			'page_comments'                 => __( 'Other comment settings', 'default' ),
+			'comments_per_page'             => __( 'Other comment settings', 'default' ),
+			'default_comments_page'         => __( 'Other comment settings', 'default' ),
+			'comment_order'                 => __( 'Other comment settings', 'default' ),
+			'comments_notify'               => __( 'E-mail me whenever', 'default' ),
+			'moderation_notify'             => __( 'E-mail me whenever', 'default' ),
+			'comment_moderation'            => __( 'Before a comment appears', 'default' ),
+			'comment_whitelist'             => __( 'Before a comment appears', 'default' ),
+			'comment_max_links'             => __( 'Comment Moderation', 'default' ),
+			'moderation_keys'               => __( 'Comment Moderation', 'default' ),
+			'blacklist_keys'                => __( 'Comment Blacklist', 'default' ),
+			'show_avatars'                  => __( 'Show Avatars', 'default' ),
+			'avatar_rating'                 => __( 'Maximum Rating', 'default' ),
+			'avatar_default'                => __( 'Default Avatar', 'default' ),
 			// Media
-			'thumbnail_size_w'              => __( 'Thumbnail Image Size', 'stream' ),
-			'thumbnail_size_h'              => __( 'Thumbnail Image Size', 'stream' ),
-			'thumbnail_crop'                => __( 'Thumbnail Image Size', 'stream' ),
-			'medium_size_w'                 => __( 'Medium Image Size', 'stream' ),
-			'medium_size_h'                 => __( 'Medium Image Size', 'stream' ),
-			'large_size_w'                  => __( 'Large Image Size', 'stream' ),
-			'large_size_h'                  => __( 'Large Image Size', 'stream' ),
-			'uploads_use_yearmonth_folders' => __( 'Uploading Files Organization', 'stream' ),
+			'thumbnail_size_w'              => __( 'Thumbnail size', 'default' ),
+			'thumbnail_size_h'              => __( 'Thumbnail size', 'default' ),
+			'thumbnail_crop'                => __( 'Thumbnail size', 'default' ),
+			'medium_size_w'                 => __( 'Medium size', 'default' ),
+			'medium_size_h'                 => __( 'Medium size', 'default' ),
+			'large_size_w'                  => __( 'Large size', 'default' ),
+			'large_size_h'                  => __( 'Large size', 'default' ),
+			'uploads_use_yearmonth_folders' => __( 'Uploading Files', 'default' ),
 			// Permalinks
-			'permalink_structure'           => __( 'Permalink structure', 'stream' ),
-			'category_base'                 => __( 'Category base', 'stream' ),
-			'tag_base'                      => __( 'Tag base', 'stream' ),
+			'permalink_structure'           => __( 'Permalink Settings', 'default' ),
+			'category_base'                 => __( 'Category base', 'default' ),
+			'tag_base'                      => __( 'Tag base', 'default' ),
 			// Network
-			'registrationnotification'      => __( 'Registration notification', 'stream' ),
-			'registration'                  => __( 'Allow new registrations', 'stream' ),
-			'add_new_users'                 => __( 'Add New Users', 'stream' ),
-			'menu_items'                    => __( 'Enable administration menus', 'stream' ),
-			'upload_space_check_disabled'   => __( 'Site upload space check', 'stream' ),
-			'blog_upload_space'             => __( 'Site upload space', 'stream' ),
-			'upload_filetypes'              => __( 'Upload file types', 'stream' ),
-			'site_name'                     => __( 'Network Title', 'stream' ),
-			'first_post'                    => __( 'First Post', 'stream' ),
-			'first_page'                    => __( 'First Page', 'stream' ),
-			'first_comment'                 => __( 'First Comment', 'stream' ),
-			'first_comment_url'             => __( 'First Comment URL', 'stream' ),
-			'first_comment_author'          => __( 'First Comment Author', 'stream' ),
-			'welcome_email'                 => __( 'Welcome Email', 'stream' ),
-			'welcome_user_email'            => __( 'Welcome User Email', 'stream' ),
-			'fileupload_maxk'               => __( 'Max upload file size', 'stream' ),
-			'global_terms_enabled'          => __( 'Terms Enabled', 'stream' ),
-			'illegal_names'                 => __( 'Banned Names', 'stream' ),
-			'limited_email_domains'         => __( 'Limited Email Registrations', 'stream' ),
-			'banned_email_domains'          => __( 'Banned Email Domains', 'stream' ),
-			'WPLANG'                        => __( 'Network Language', 'stream' ),
-			'admin_email'                   => __( 'Network Admin Email', 'stream' ),
+			'registrationnotification'      => __( 'Registration notification', 'default' ),
+			'registration'                  => __( 'Allow new registrations', 'default' ),
+			'add_new_users'                 => __( 'Add New Users', 'default' ),
+			'menu_items'                    => __( 'Enable administration menus', 'default' ),
+			'upload_space_check_disabled'   => __( 'Site upload space check', 'default' ),
+			'blog_upload_space'             => __( 'Site upload space', 'default' ),
+			'upload_filetypes'              => __( 'Upload file types', 'default' ),
+			'site_name'                     => __( 'Network Title', 'default' ),
+			'first_post'                    => __( 'First Post', 'default' ),
+			'first_page'                    => __( 'First Page', 'default' ),
+			'first_comment'                 => __( 'First Comment', 'default' ),
+			'first_comment_url'             => __( 'First Comment URL', 'default' ),
+			'first_comment_author'          => __( 'First Comment Author', 'default' ),
+			'welcome_email'                 => __( 'Welcome Email', 'default' ),
+			'welcome_user_email'            => __( 'Welcome User Email', 'default' ),
+			'fileupload_maxk'               => __( 'Max upload file size', 'default' ),
+			'global_terms_enabled'          => __( 'Terms Enabled', 'default' ),
+			'illegal_names'                 => __( 'Banned Names', 'default' ),
+			'limited_email_domains'         => __( 'Limited Email Registrations', 'default' ),
+			'banned_email_domains'          => __( 'Banned Email Domains', 'default' ),
+			'WPLANG'                        => __( 'Network Language', 'default' ),
+			'admin_email'                   => __( 'Network Admin Email', 'default' ),
 			// Other
 			'wp_stream_db'                  => __( 'Stream Database Version', 'stream' ),
 		);
@@ -319,14 +319,14 @@ class WP_Stream_Connector_Settings extends WP_Stream_Connector {
 		$labels = array(
 			'theme_mods' => array(
 				// Custom Background
-				'background_image'       => __( 'Background Image', 'stream' ),
-				'background_position_x'  => __( 'Background Position', 'stream' ),
-				'background_repeat'      => __( 'Background Repeat', 'stream' ),
-				'background_attachment'  => __( 'Background Attachment', 'stream' ),
-				'background_color'       => __( 'Background Color', 'stream' ),
+				'background_image'       => __( 'Background Image', 'default' ),
+				'background_position_x'  => __( 'Background Position', 'default' ),
+				'background_repeat'      => __( 'Background Repeat', 'default' ),
+				'background_attachment'  => __( 'Background Attachment', 'default' ),
+				'background_color'       => __( 'Background Color', 'default' ),
 				// Custom Header
-				'header_image'           => __( 'Header Image', 'stream' ),
-				'header_textcolor'       => __( 'Text Color', 'stream' ),
+				'header_image'           => __( 'Header Image', 'default' ),
+				'header_textcolor'       => __( 'Text Color', 'default' ),
 			),
 		);
 

--- a/connectors/taxonomies.php
+++ b/connectors/taxonomies.php
@@ -3,7 +3,7 @@
 class WP_Stream_Connector_Taxonomies extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
@@ -19,7 +19,7 @@ class WP_Stream_Connector_Taxonomies extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -45,9 +45,9 @@ class WP_Stream_Connector_Taxonomies extends WP_Stream_Connector {
 	public static $context_labels;
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
 		return __( 'Taxonomies', 'stream' );

--- a/connectors/users.php
+++ b/connectors/users.php
@@ -3,7 +3,7 @@
 class WP_Stream_Connector_Users extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
@@ -18,7 +18,7 @@ class WP_Stream_Connector_Users extends WP_Stream_Connector {
 	protected static $_users_object_pre_deleted = array();
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -36,12 +36,12 @@ class WP_Stream_Connector_Users extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Users', 'stream' );
+		return __( 'Users', 'default' );
 	}
 
 	/**
@@ -54,10 +54,10 @@ class WP_Stream_Connector_Users extends WP_Stream_Connector {
 			'updated'         => __( 'Updated', 'stream' ),
 			'created'         => __( 'Created', 'stream' ),
 			'deleted'         => __( 'Deleted', 'stream' ),
-			'password-reset'  => __( 'Password Reset', 'stream' ),
-			'forgot-password' => __( 'Forgot Password', 'stream' ),
-			'login'           => __( 'Login', 'stream' ),
-			'logout'          => __( 'Logout', 'stream' ),
+			'password-reset'  => __( 'Password Reset', 'default' ),
+			'forgot-password' => __( 'Lost Password', 'default' ),
+			'login'           => __( 'Log In', 'default' ),
+			'logout'          => __( 'Log Out', 'default' ),
 			'failed_login'    => __( 'Failed Login', 'stream' ),
 		);
 	}
@@ -69,7 +69,7 @@ class WP_Stream_Connector_Users extends WP_Stream_Connector {
 	 */
 	public static function get_context_labels() {
 		return array(
-			'users'    => __( 'Users', 'stream' ),
+			'users'    => __( 'Users', 'default' ),
 			'sessions' => __( 'Sessions', 'stream' ),
 			'profiles' => __( 'Profiles', 'stream' ),
 		);
@@ -86,7 +86,7 @@ class WP_Stream_Connector_Users extends WP_Stream_Connector {
 	public static function action_links( $links, $record ) {
 		if ( $record->object_id ) {
 			if ( $link = get_edit_user_link( $record->object_id ) ) {
-				$links [ __( 'Edit Profile', 'stream' ) ] = $link;
+				$links [ __( 'Edit User', 'default' ) ] = $link;
 			}
 		}
 

--- a/connectors/widgets.php
+++ b/connectors/widgets.php
@@ -3,14 +3,14 @@
 class WP_Stream_Connector_Widgets extends WP_Stream_Connector {
 
 	/**
-	 * Context name
+	 * Connector slug
 	 *
 	 * @var string
 	 */
 	public static $name = 'widgets';
 
 	/**
-	 * Actions registered for this context
+	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
@@ -22,12 +22,12 @@ class WP_Stream_Connector_Widgets extends WP_Stream_Connector {
 	);
 
 	/**
-	 * Return translated context label
+	 * Return translated connector label
 	 *
-	 * @return string Translated context label
+	 * @return string Translated connector label
 	 */
 	public static function get_label() {
-		return __( 'Widgets', 'stream' );
+		return __( 'Widgets', 'default' );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class WP_Stream_Connector_Widgets extends WP_Stream_Connector {
 			$labels[ $sidebar['id'] ] = $sidebar['name'];
 		}
 
-		$labels['wp_inactive_widgets'] = esc_html__( 'Inactive Widgets', 'stream' );
+		$labels['wp_inactive_widgets'] = esc_html__( 'Inactive Widgets', 'default' );
 
 		return $labels;
 	}
@@ -266,7 +266,7 @@ class WP_Stream_Connector_Widgets extends WP_Stream_Connector {
 
 		if ( isset( $changed ) ) {
 			$sidebar      = $changed;
-			$sidebar_name = isset( $labels[ $sidebar ] ) ? $labels[ $sidebar ] : esc_html__( 'Widgets', 'stream' );
+			$sidebar_name = isset( $labels[ $sidebar ] ) ? $labels[ $sidebar ] : esc_html__( 'Widgets', 'default' );
 
 			// Saving this in a global var, so it can be accessed and
 			// executed by self::callback_update_option_sidebars_widgets
@@ -313,7 +313,7 @@ class WP_Stream_Connector_Widgets extends WP_Stream_Connector {
 		foreach ( $sidebars as $_sidebar_id => $_sidebar ) {
 			if ( is_array( $_sidebar ) && in_array( $id, $_sidebar ) ) {
 				$sidebar      = $_sidebar_id;
-				$sidebar_name = isset( $labels[ $sidebar ] ) ? $labels[ $sidebar ] : esc_html__( 'Widgets', 'stream' );
+				$sidebar_name = isset( $labels[ $sidebar ] ) ? $labels[ $sidebar ] : esc_html__( 'Widgets', 'default' );
 				break;
 			}
 		}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -129,7 +129,7 @@ class WP_Stream_Admin {
 		self::$screen_id['settings'] = add_submenu_page(
 			self::RECORDS_PAGE_SLUG,
 			__( 'Stream Settings', 'stream' ),
-			__( 'Settings', 'stream' ),
+			__( 'Settings', 'default' ),
 			self::SETTINGS_CAP,
 			self::SETTINGS_PAGE_SLUG,
 			array( __CLASS__, 'render_page' )
@@ -316,7 +316,7 @@ class WP_Stream_Admin {
 			} else {
 				$admin_page_url = add_query_arg( array( 'page' => self::SETTINGS_PAGE_SLUG ), admin_url( self::ADMIN_PARENT_PAGE ) );
 			}
-			$links[] = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'stream' ) );
+			$links[] = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'default' ) );
 
 			$url = add_query_arg(
 				array(

--- a/includes/connector.php
+++ b/includes/connector.php
@@ -3,14 +3,14 @@
 abstract class WP_Stream_Connector {
 
 	/**
-	* Name/slug of the context
+	* Connector slug
 	*
 	* @var string
 	*/
 	public static $name = null;
 
 	/**
-	* Actions this context is hooked to
+	* Actions registered for this connector
 	*
 	* @var array
 	*/

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -103,7 +103,7 @@ class WP_Stream_Dashboard_Widget {
 			'view-all',
 			esc_attr__( 'View all records', 'stream' ),
 			esc_url( $records_link ),
-			esc_html__( 'View All', 'stream' )
+			esc_html__( 'View All', 'default' )
 		);
 
 		$page_links    = array();
@@ -121,7 +121,7 @@ class WP_Stream_Dashboard_Widget {
 		$page_links[] = sprintf(
 			'<a class="%s" title="%s" href="%s" data-page="1">%s</a>',
 			'first-page' . $disable_first,
-			esc_attr__( 'Go to the first page', 'stream' ),
+			esc_attr__( 'Go to the first page', 'default' ),
 			esc_url( remove_query_arg( 'paged', $records_link ) ),
 			'&laquo;'
 		);
@@ -129,7 +129,7 @@ class WP_Stream_Dashboard_Widget {
 		$page_links[] = sprintf(
 			'<a class="%s" title="%s" href="%s" data-page="%s">%s</a>',
 			'prev-page' . $disable_first,
-			esc_attr__( 'Go to the previous page', 'stream' ),
+			esc_attr__( 'Go to the previous page', 'default' ),
 			esc_url( add_query_arg( 'paged', max( 1, $current - 1 ), $records_link ) ),
 			max( 1, $current - 1 ),
 			'&lsaquo;'
@@ -141,7 +141,7 @@ class WP_Stream_Dashboard_Widget {
 		$page_links[] = sprintf(
 			'<a class="%s" title="%s" href="%s" data-page="%s">%s</a>',
 			'next-page' . $disable_last,
-			esc_attr__( 'Go to the next page', 'stream' ),
+			esc_attr__( 'Go to the next page', 'default' ),
 			esc_url( add_query_arg( 'paged', min( $total_pages, $current + 1 ), $records_link ) ),
 			min( $total_pages, $current + 1 ),
 			'&rsaquo;'
@@ -150,7 +150,7 @@ class WP_Stream_Dashboard_Widget {
 		$page_links[] = sprintf(
 			'<a class="%s" title="%s" href="%s" data-page="%s">%s</a>',
 			'last-page' . $disable_last,
-			esc_attr__( 'Go to the last page', 'stream' ),
+			esc_attr__( 'Go to the last page', 'default' ),
 			esc_url( add_query_arg( 'paged', $total_pages, $records_link ) ),
 			$total_pages,
 			'&raquo;'
@@ -300,7 +300,5 @@ class WP_Stream_Dashboard_Widget {
 
 		return $items;
 	}
-
-
 
 }

--- a/includes/date-interval.php
+++ b/includes/date-interval.php
@@ -48,7 +48,7 @@ class WP_Stream_Date_Interval {
 			'wp_stream_predefined_date_intervals',
 			array(
 				'today' => array(
-					'label' => esc_html__( 'Today', 'stream' ),
+					'label' => esc_html__( 'Today', 'default' ),
 					'start' => Carbon::today( $timezone )->startOfDay(),
 					'end'   => Carbon::today( $timezone )->startOfDay(),
 				),

--- a/includes/feeds.php
+++ b/includes/feeds.php
@@ -132,9 +132,9 @@ class WP_Stream_Feeds {
 					</p>
 					<p class="description"><?php esc_html_e( 'This is your private key used for accessing feeds of Stream Records securely. You can change your key at any time by generating a new one using the link above.', 'stream' ) ?></p>
 					<p class="wp-stream-feeds-links">
-						<a href="<?php echo esc_url( add_query_arg( array( 'type' => 'xml' ), $link )  ) ?>" class="rss-feed" target="_blank"><?php echo esc_html_e( 'RSS Feed' ) ?></a>
+						<a href="<?php echo esc_url( add_query_arg( array( 'type' => 'xml' ), $link )  ) ?>" class="rss-feed" target="_blank"><?php echo esc_html_e( 'RSS Feed', 'stream' ) ?></a>
 						|
-						<a href="<?php echo esc_url( add_query_arg( array( 'type' => 'json' ), $link ) ) ?>" class="json-feed" target="_blank"><?php echo esc_html_e( 'JSON Feed' ) ?></a>
+						<a href="<?php echo esc_url( add_query_arg( array( 'type' => 'json' ), $link ) ) ?>" class="json-feed" target="_blank"><?php echo esc_html_e( 'JSON Feed', 'stream' ) ?></a>
 					</p>
 				</td>
 			</tr>

--- a/includes/list-table.php
+++ b/includes/list-table.php
@@ -50,9 +50,9 @@ class WP_Stream_List_Table extends WP_List_Table {
 		return apply_filters(
 			'wp_stream_list_table_columns',
 			array(
-				'date'      => __( 'Date', 'stream' ),
-				'summary'   => __( 'Summary', 'stream' ),
-				'author'    => __( 'Author', 'stream' ),
+				'date'      => __( 'Date', 'default' ),
+				'summary'   => __( 'Summary', 'default' ),
+				'author'    => __( 'Author', 'default' ),
 				'connector' => __( 'Connector', 'stream' ),
 				'context'   => __( 'Context', 'stream' ),
 				'action'    => __( 'Action', 'stream' ),
@@ -541,7 +541,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 			$filters_string .= $this->filter_select( $name, $data['title'], isset( $data['items'] ) ? $data['items'] : array(), isset( $data['ajax'] ) && $data['ajax'] );
 		}
 
-		$filters_string .= sprintf( '<input type="submit" id="record-query-submit" class="button" value="%s">', __( 'Filter', 'stream' ) );
+		$filters_string .= sprintf( '<input type="submit" id="record-query-submit" class="button" value="%s">', __( 'Filter', 'default' ) );
 
 		$url = self_admin_url( WP_Stream_Admin::ADMIN_PARENT_PAGE );
 
@@ -613,7 +613,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 
 			<select class="field-predefined hide-if-no-js" name="date_predefined" data-placeholder="<?php _e( 'All Time', 'stream' ); ?>">
 				<option></option>
-				<option value="custom" <?php selected( 'custom' === $date_predefined ); ?>><?php esc_attr_e( 'Custom', 'stream' ) ?></option>
+				<option value="custom" <?php selected( 'custom' === $date_predefined ); ?>><?php esc_attr_e( 'Custom', 'default' ) ?></option>
 				<?php foreach ( $items as $key => $interval ) {
 					printf(
 						'<option value="%s" data-from="%s" data-to="%s" %s>%s</option>',
@@ -632,7 +632,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 					<input type="text"
 						   name="date_from"
 						   class="date-picker field-from"
-						   placeholder="<?php esc_attr_e( 'Start date', 'stream' ) ?>"
+						   placeholder="<?php esc_attr_e( 'Start Date', 'default' ) ?>"
 						   value="<?php echo esc_attr( $date_from ) ?>">
 				</div>
 				<span class="connector dashicons"></span>
@@ -642,7 +642,7 @@ class WP_Stream_List_Table extends WP_List_Table {
 					<input type="text"
 						   name="date_to"
 						   class="date-picker field-to"
-						   placeholder="<?php esc_attr_e( 'End date', 'stream' ) ?>"
+						   placeholder="<?php esc_attr_e( 'End Date', 'default' ) ?>"
 						   value="<?php echo esc_attr( $date_to ) ?>">
 				</div>
 			</div>

--- a/includes/network.php
+++ b/includes/network.php
@@ -82,7 +82,7 @@ class WP_Stream_Network {
 	public static function get_network_blog() {
 		$blog           = new stdClass;
 		$blog->blog_id  = 0;
-		$blog->blogname = __( 'Network Admin', 'stream' );
+		$blog->blogname = __( 'Network Admin', 'default' );
 
 		return $blog;
 	}
@@ -126,7 +126,7 @@ class WP_Stream_Network {
 		WP_Stream_Admin::$screen_id['network_settings'] = add_submenu_page(
 			WP_Stream_Admin::RECORDS_PAGE_SLUG,
 			__( 'Stream Network Settings', 'stream' ),
-			__( 'Network Settings', 'stream' ),
+			__( 'Network Settings', 'default' ),
 			WP_Stream_Admin::SETTINGS_CAP,
 			self::NETWORK_SETTINGS_PAGE_SLUG,
 			array( 'WP_Stream_Admin', 'render_page' )
@@ -135,7 +135,7 @@ class WP_Stream_Network {
 		if ( ! WP_Stream_Admin::$disable_access ) {
 			WP_Stream_Admin::$screen_id['default_settings'] = add_submenu_page(
 				WP_Stream_Admin::RECORDS_PAGE_SLUG,
-				__( 'New Site Settings', 'stream' ),
+				__( 'New Site Settings', 'default' ),
 				__( 'Site Defaults', 'stream' ),
 				WP_Stream_Admin::SETTINGS_CAP,
 				self::DEFAULT_SETTINGS_PAGE_SLUG,
@@ -287,7 +287,7 @@ class WP_Stream_Network {
 			$new_fields['general']['fields'][] = array(
 				'name'        => 'enable_site_access',
 				'title'       => __( 'Enable Site Access', 'stream' ),
-				'after_field' => __( 'Enabled' ),
+				'after_field' => __( 'Enabled', 'stream' ),
 				'default'     => 1,
 				'desc'        => __( 'When site access is disabled Stream can only be accessed from the network administration.', 'stream' ),
 				'type'        => 'checkbox',
@@ -392,7 +392,7 @@ class WP_Stream_Network {
 		}
 
 		if ( ! count( get_settings_errors() ) ) {
-			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'stream' ), 'updated' );
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'default' ), 'updated' );
 		}
 
 		set_transient( 'settings_errors', get_settings_errors(), 30 );

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -236,7 +236,7 @@ class WP_Stream_Settings {
 		if ( empty( self::$fields ) ) {
 			$fields = array(
 				'general' => array(
-					'title'  => esc_html__( 'General', 'stream' ),
+					'title'  => esc_html__( 'General', 'default' ),
 					'fields' => array(
 						array(
 							'name'        => 'role_access',
@@ -298,7 +298,7 @@ class WP_Stream_Settings {
 					'fields' => array(
 						array(
 							'name'        => 'authors_and_roles',
-							'title'       => esc_html__( 'Authors & Roles', 'stream' ),
+							'title'       => __( 'Authors &amp; Roles', 'stream' ),
 							'type'        => 'select2_user_role',
 							'desc'        => esc_html__( 'No activity will be logged for these authors and/or roles.', 'stream' ),
 							'choices'     => self::get_roles(),


### PR DESCRIPTION
Resolves #534

I've gone through all the connectors and includes to use the `default` textdomain wherever possible instead of always using `stream`. I did this by checking a core language pack PO file and ensuring the strings there were identical to ours.

@lukecarbis Please review
