### PR TITLE
Reworded readme.txt slightly to fix #539 and partial sentence.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Every logged-in user action is logged in a user activity stream and organized fo
 
 Built with performance in mind, Stream won't pollute your default posts table with records or slow down content querying on your site.
 
-Visit the Stream Extensions screen inside the plugin to learn more about the powerful
+Visit the Stream Extensions screen inside the plugin to learn more about making Stream even more powerful.
 
 **Extensions:**
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Every logged-in user action is logged in a user activity stream and organized fo
 
 Built with performance in mind, Stream won't pollute your default posts table with records or slow down content querying on your site.
 
-Visit the Stream Extensions screen inside the plugin to learn more about the powerful
+Visit the Stream Extensions screen inside the plugin to learn more about making Stream even more powerful.
 
 **Extensions:**
 


### PR DESCRIPTION
Perhaps this change will also bump the cached version that seems to be on WP.org to fix the list formatting mentioned in #539.
