### PR TITLE
Load connectors twice to properly capture labels registered on init

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -98,8 +98,10 @@ class WP_Stream {
 		add_action( 'plugins_loaded', array( 'WP_Stream_Log', 'load' ) );
 
 		// Load connectors after widgets_init, but before the default of 10
+		// Then load them again much later to properly capture any labels registered on init
 		require_once WP_STREAM_INC_DIR . 'connectors.php';
 		add_action( 'init', array( 'WP_Stream_Connectors', 'load' ), 9 );
+		add_action( 'init', array( 'WP_Stream_Connectors', 'load' ), 99 );
 
 		// Load query class
 		require_once WP_STREAM_INC_DIR . 'query.php';


### PR DESCRIPTION
Fixes #565

I would like to get @shadyvb and @lukecarbis to weigh in here.

The problem is that we need to load connectors early enough to capture certain actions (such as widgets and user switching before priority 10) and late enough to grab registered labels for post types and taxonomies.

I don't see any other way to solve the problem than to load connectors twice, so I opted to fire late the second time at priority 99.
