### PR TITLE
Update the .PO and .POT files for the version 1.4.6

### DIFF
--- a/languages/stream.po
+++ b/languages/stream.po
@@ -2,941 +2,1710 @@
 # This file is distributed under the same license as the Stream package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Stream 1.0.3\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tag/stream\n"
-"POT-Creation-Date: 2014-01-21 17:35:57+00:00\n"
+"Project-Id-Version: Stream 1.4.6\n"
+"Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/wp-stream\n"
+"POT-Creation-Date: 2014-06-25 02:57:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2014-01-22 01:37+0700\n"
-"Last-Translator: Dzikri Aziz <kvcrvt@gmail.com>\n"
-"Language-Team: X-Team <wordpress@x-team.com>\n"
-"X-Generator: Poedit 1.5.5\n"
-"Language: English\n"
-"X-Poedit-SourceCharset: UTF-8\n"
+"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 
-#: connectors/comments.php:34 connectors/comments.php:66
-msgid "Comments"
+#: connectors/blogs.php:39
+msgid "Sites"
 msgstr ""
 
-#: connectors/comments.php:44 connectors/menus.php:37 connectors/posts.php:37
+#: connectors/blogs.php:49 connectors/editor.php:53
+#: connectors/installer.php:50 connectors/media.php:43 connectors/menus.php:40
+#: connectors/posts.php:38 connectors/settings.php:104
 #: connectors/taxonomies.php:64 connectors/users.php:53
+#: connectors/widgets.php:43
+msgid "Updated"
+msgstr ""
+
+#: connectors/blogs.php:50 connectors/comments.php:46 connectors/menus.php:39
+#: connectors/posts.php:39 connectors/taxonomies.php:63
+#: connectors/users.php:54
 msgid "Created"
 msgstr ""
 
-#: connectors/comments.php:45 connectors/installer.php:47
-msgid "Edited"
+#: connectors/blogs.php:51
+msgid "Archived"
 msgstr ""
 
-#: connectors/comments.php:46
-msgid "Replied"
-msgstr ""
-
-#: connectors/comments.php:47
-msgid "Approved"
-msgstr ""
-
-#: connectors/comments.php:48
-msgid "Unapproved"
-msgstr ""
-
-#: connectors/comments.php:49 connectors/posts.php:38
-msgid "Trashed"
-msgstr ""
-
-#: connectors/comments.php:50
-msgid "Restored"
-msgstr ""
-
-#: connectors/comments.php:51
-msgid "Marked as Spam"
-msgstr ""
-
-#: connectors/comments.php:52
-msgid "Unmarked as Spam"
-msgstr ""
-
-#: connectors/comments.php:53 connectors/installer.php:46
-#: connectors/media.php:42 connectors/menus.php:39 connectors/posts.php:39
-#: connectors/taxonomies.php:66 connectors/users.php:54
-#: connectors/widgets.php:39
+#: connectors/blogs.php:52 connectors/comments.php:55
+#: connectors/installer.php:48 connectors/media.php:44 connectors/menus.php:41
+#: connectors/posts.php:42 connectors/taxonomies.php:65
+#: connectors/users.php:55 connectors/widgets.php:41
 msgid "Deleted"
 msgstr ""
 
+#: connectors/blogs.php:83 connectors/blogs.php:88
+msgid "Site Admin"
+msgstr ""
+
+#: connectors/blogs.php:99
+msgid "Site Settings"
+msgstr ""
+
+#: connectors/blogs.php:113
+msgctxt "1. Site name"
+msgid "A new site called \"%1$s\" has been created."
+msgstr ""
+
+#: connectors/blogs.php:135
+msgctxt "1. Site name"
+msgid "A new site called \"%1$s\" has been registered."
+msgstr ""
+
+#: connectors/blogs.php:165
+msgctxt "1. User's name, 2. Site name, 3. Role"
+msgid "%1$s has been added to the site \"%2$s\" with %3$s capabilities."
+msgstr ""
+
+#: connectors/blogs.php:195
+msgctxt "1. User's name, 2. Site name"
+msgid "%1$s has been removed from the site \"%2$s\"."
+msgstr ""
+
+#: connectors/blogs.php:214
+msgid "marked as spam"
+msgstr ""
+
+#: connectors/blogs.php:222
+msgid "marked as not spam"
+msgstr ""
+
+#: connectors/blogs.php:230
+msgid "marked as mature"
+msgstr ""
+
+#: connectors/blogs.php:238
+msgid "marked as not mature"
+msgstr ""
+
+#: connectors/blogs.php:246
+msgid "archived"
+msgstr ""
+
+#: connectors/blogs.php:254
+msgid "restored from archive"
+msgstr ""
+
+#: connectors/blogs.php:262
+msgid "deleted"
+msgstr ""
+
+#: connectors/blogs.php:270
+msgid "restored"
+msgstr ""
+
+#: connectors/blogs.php:280
+msgid "marked as public"
+msgstr ""
+
+#: connectors/blogs.php:282
+msgid "marked as private"
+msgstr ""
+
+#: connectors/blogs.php:295
+msgctxt "1. Site name, 2. Status"
+msgid "\"%1$s\" has been %2$s."
+msgstr ""
+
+#: connectors/comments.php:36 connectors/comments.php:68
+msgid "Comments"
+msgstr ""
+
+#: connectors/comments.php:47 connectors/installer.php:49
+msgid "Edited"
+msgstr ""
+
+#: connectors/comments.php:48
+msgid "Replied"
+msgstr ""
+
+#: connectors/comments.php:49
+msgid "Approved"
+msgstr ""
+
+#: connectors/comments.php:50
+msgid "Unapproved"
+msgstr ""
+
+#: connectors/comments.php:51 connectors/posts.php:40
+msgid "Trashed"
+msgstr ""
+
+#: connectors/comments.php:52 connectors/posts.php:41
+msgid "Restored"
+msgstr ""
+
+#: connectors/comments.php:53
+msgid "Marked as Spam"
+msgstr ""
+
 #: connectors/comments.php:54
+msgid "Unmarked as Spam"
+msgstr ""
+
+#: connectors/comments.php:56
 msgid "Duplicate"
 msgstr ""
 
-#: connectors/comments.php:55
+#: connectors/comments.php:57
 msgid "Throttled"
 msgstr ""
 
-#: connectors/comments.php:84 connectors/taxonomies.php:93
+#: connectors/comments.php:86
 msgid "Edit"
 msgstr ""
 
-#: connectors/comments.php:86
+#: connectors/comments.php:89
 msgid "Unapprove"
 msgstr ""
 
-#: connectors/comments.php:94
+#: connectors/comments.php:97
 msgid "Approve"
 msgstr ""
 
-#: connectors/comments.php:125
+#: connectors/comments.php:129
 msgid "Guest"
 msgstr ""
 
-#: connectors/comments.php:161
+#: connectors/comments.php:165
 msgid "a logged out user"
 msgstr ""
 
-#: connectors/comments.php:165
+#: connectors/comments.php:169
 msgid "Comment flooding by %s detected and prevented"
 msgstr ""
 
-#: connectors/comments.php:181 connectors/comments.php:224
-#: connectors/comments.php:248 connectors/comments.php:272
-#: connectors/comments.php:296 connectors/comments.php:320
-#: connectors/comments.php:344 connectors/comments.php:371
-#: connectors/comments.php:398
+#: connectors/comments.php:190 connectors/comments.php:239
+#: connectors/comments.php:269 connectors/comments.php:299
+#: connectors/comments.php:329 connectors/comments.php:359
+#: connectors/comments.php:389 connectors/comments.php:421
+#: connectors/comments.php:454
 msgid "a post"
 msgstr ""
 
-#: connectors/comments.php:182
+#: connectors/comments.php:191
 msgid "approved automatically"
 msgstr ""
 
-#: connectors/comments.php:182
+#: connectors/comments.php:191
 msgid "pending approval"
 msgstr ""
 
-#: connectors/comments.php:189
+#: connectors/comments.php:198
 msgctxt ""
 "1: Parent comment's author, 2: Comment author, 3: Post title, 4: Comment "
 "status"
 msgid "Reply to %1$s's comment by %2$s on %3$s %4$s"
 msgstr ""
 
-#: connectors/comments.php:201
+#: connectors/comments.php:210
 msgctxt "1: Comment author, 2: Post title 3: Comment status"
 msgid "New comment by %1$s on %2$s %3$s"
 msgstr ""
 
-#: connectors/comments.php:227
+#: connectors/comments.php:242
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s edited"
 msgstr ""
 
-#: connectors/comments.php:251
+#: connectors/comments.php:272
+msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s deleted permanently"
-msgid_plural "1: Comment author, 2: Post title"
-msgstr[0] ""
-msgstr[1] ""
+msgstr ""
 
-#: connectors/comments.php:275
+#: connectors/comments.php:302
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s trashed"
 msgstr ""
 
-#: connectors/comments.php:299
+#: connectors/comments.php:332
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s restored"
 msgstr ""
 
-#: connectors/comments.php:323
+#: connectors/comments.php:362
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s marked as spam"
 msgstr ""
 
-#: connectors/comments.php:347
+#: connectors/comments.php:392
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s unmarked as spam"
 msgstr ""
 
-#: connectors/comments.php:374
+#: connectors/comments.php:424
 msgctxt "Comment status transition. 1: Comment author, 2: Post title"
 msgid "%1$s's comment %2$s"
 msgstr ""
 
-#: connectors/comments.php:401
+#: connectors/comments.php:457
 msgctxt "1: Comment author, 2: Post title"
 msgid "Duplicate comment by %1$s prevented on %2$s"
 msgstr ""
 
-#: connectors/installer.php:33
+#: connectors/editor.php:43
+msgid "Theme Editor"
+msgstr ""
+
+#: connectors/editor.php:83
+msgid "\"%1$s\" in \"%2$s\" updated"
+msgstr ""
+
+#: connectors/editor.php:100
+msgid "Edit File"
+msgstr ""
+
+#: connectors/editor.php:108
+msgid "Edit Theme"
+msgstr ""
+
+#: connectors/installer.php:35
 msgid "Installer"
 msgstr ""
 
-#: connectors/installer.php:43
+#: connectors/installer.php:45
 msgid "Installed"
 msgstr ""
 
-#: connectors/installer.php:44
+#: connectors/installer.php:46 includes/updater.php:213
 msgid "Activated"
 msgstr ""
 
-#: connectors/installer.php:45 connectors/widgets.php:40
+#: connectors/installer.php:47 connectors/widgets.php:42
 msgid "Deactivated"
 msgstr ""
 
-#: connectors/installer.php:48 connectors/media.php:41 connectors/menus.php:38
-#: connectors/posts.php:36 connectors/settings.php:48
-#: connectors/taxonomies.php:65 connectors/users.php:52
-#: connectors/widgets.php:41
-msgid "Updated"
-msgstr ""
-
-#: connectors/installer.php:59
+#: connectors/installer.php:61
 msgid "Plugins"
 msgstr ""
 
-#: connectors/installer.php:60
+#: connectors/installer.php:62
 msgid "Themes"
 msgstr ""
 
-#: connectors/installer.php:61
+#: connectors/installer.php:63
 msgid "WordPress"
 msgstr ""
 
-#: connectors/installer.php:78
+#: connectors/installer.php:80
 msgid "About"
 msgstr ""
 
-#: connectors/installer.php:80
+#: connectors/installer.php:82
 msgid "View Release Notes"
 msgstr ""
 
-#: connectors/installer.php:110
-msgid "Installed %s: %s %s"
+#: connectors/installer.php:135
+msgctxt ""
+"Plugin/theme installation. 1: Type (plugin/theme), 2: Plugin/theme name, 3: "
+"Plugin/theme version"
+msgid "Installed %1$s: %2$s %3$s"
 msgstr ""
 
-#: connectors/installer.php:138
-msgid "Updated %s: %s to %s"
+#: connectors/installer.php:143
+msgctxt ""
+"Plugin/theme update. 1: Type (plugin/theme), 2: Plugin/theme name, 3: Plugin/"
+"theme version"
+msgid "Updated %1$s: %2$s %3$s"
 msgstr ""
 
-#: connectors/installer.php:166
-msgid "\"%s\" plugin activated %s"
+#: connectors/installer.php:205 connectors/installer.php:222
+#: connectors/installer.php:309
+msgid "network wide"
 msgstr ""
 
-#: connectors/installer.php:178
-msgid "\"%s\" plugin deactivated %s"
+#: connectors/installer.php:208
+msgctxt "1: Plugin name, 2: Single site or network wide"
+msgid "\"%1$s\" plugin activated %2$s"
 msgstr ""
 
-#: connectors/installer.php:188
+#: connectors/installer.php:225
+msgctxt "1: Plugin name, 2: Single site or network wide"
+msgid "\"%1$s\" plugin deactivated %2$s"
+msgstr ""
+
+#: connectors/installer.php:240
 msgid "\"%s\" theme activated"
 msgstr ""
 
-#: connectors/installer.php:203
+#: connectors/installer.php:269
 msgid "\"%s\" theme deleted"
 msgstr ""
 
-#: connectors/installer.php:232
+#: connectors/installer.php:312
 msgid "\"%s\" plugin deleted"
 msgstr ""
 
-#: connectors/installer.php:271
-msgid "Edited %s: %s"
+#: connectors/installer.php:359
+msgctxt "Plugin/theme editing. 1: Type (plugin/theme), 2: Plugin/theme name"
+msgid "Edited %1$s: %2$s"
 msgstr ""
 
-#: connectors/installer.php:285
+#: connectors/installer.php:379
 msgid "WordPress auto-updated to %s"
 msgstr ""
 
-#: connectors/installer.php:287
+#: connectors/installer.php:381
 msgid "WordPress updated to %s"
 msgstr ""
 
-#: connectors/media.php:29 connectors/media.php:55 connectors/settings.php:64
+#: connectors/media.php:31 connectors/settings.php:120
 msgid "Media"
 msgstr ""
 
-#: connectors/media.php:39
+#: connectors/media.php:41
 msgid "Attached"
 msgstr ""
 
-#: connectors/media.php:40
+#: connectors/media.php:42
 msgid "Uploaded"
 msgstr ""
 
-#: connectors/media.php:43 connectors/menus.php:40
+#: connectors/media.php:45 connectors/menus.php:42
 msgid "Assigned"
 msgstr ""
 
-#: connectors/media.php:44 connectors/menus.php:41
+#: connectors/media.php:46 connectors/menus.php:43
 msgid "Unassigned"
 msgstr ""
 
-#: connectors/media.php:70
+#: connectors/media.php:59
+msgid "Image"
+msgstr ""
+
+#: connectors/media.php:60
+msgid "Audio"
+msgstr ""
+
+#: connectors/media.php:61
+msgid "Video"
+msgstr ""
+
+#: connectors/media.php:62
+msgid "Document"
+msgstr ""
+
+#: connectors/media.php:63
+msgid "Spreadsheet"
+msgstr ""
+
+#: connectors/media.php:64
+msgid "Interactive"
+msgstr ""
+
+#: connectors/media.php:65
+msgid "Text"
+msgstr ""
+
+#: connectors/media.php:66
+msgid "Archive"
+msgstr ""
+
+#: connectors/media.php:67
+msgid "Code"
+msgstr ""
+
+#: connectors/media.php:105
 msgid "Edit Media"
 msgstr ""
 
-#: connectors/media.php:73 connectors/posts.php:70
-#: connectors/taxonomies.php:94
+#: connectors/media.php:108 connectors/posts.php:101
+#: connectors/taxonomies.php:99
 msgid "View"
 msgstr ""
 
-#: connectors/media.php:87
-msgid "Attached \"%s\" to \"%s\""
+#: connectors/media.php:123
+msgctxt "1: Attachment title, 2: Parent post title"
+msgid "Attached \"%1$s\" to \"%2$s\""
 msgstr ""
 
-#: connectors/media.php:89
+#: connectors/media.php:129
 msgid "Added \"%s\" to Media library"
 msgstr ""
 
-#: connectors/media.php:111
+#: connectors/media.php:154
 msgid "Updated \"%s\""
 msgstr ""
 
-#: connectors/media.php:131 connectors/menus.php:128
+#: connectors/media.php:175
 msgid "Deleted \"%s\""
 msgstr ""
 
-#: connectors/media.php:146
+#: connectors/media.php:198
 msgid "Edited image \"%s\""
 msgstr ""
 
-#: connectors/menus.php:27
+#: connectors/menus.php:29
 msgid "Menus"
 msgstr ""
 
-#: connectors/menus.php:80
+#: connectors/menus.php:84
 msgid "Edit Menu"
 msgstr ""
 
-#: connectors/menus.php:94
+#: connectors/menus.php:100
 msgid "Created new menu \"%s\""
 msgstr ""
 
-#: connectors/menus.php:112
+#: connectors/menus.php:120
+msgctxt "Menu name"
 msgid "Updated menu \"%s\""
 msgstr ""
 
-#: connectors/menus.php:163
-msgid "\"%s\" has been unassigned from \"%s\""
+#: connectors/menus.php:137
+msgctxt "Menu name"
+msgid "Deleted \"%s\""
 msgstr ""
 
-#: connectors/menus.php:167
-msgid "\"%s\" has been assigned to \"%s\""
+#: connectors/menus.php:175
+msgctxt "1: Menu name, 2: Theme location"
+msgid "\"%1$s\" has been unassigned from \"%2$s\""
 msgstr ""
 
-#: connectors/posts.php:26
+#: connectors/menus.php:183
+msgctxt "1: Menu name, 2: Theme location"
+msgid "\"%1$s\" has been assigned to \"%2$s\""
+msgstr ""
+
+#: connectors/posts.php:28
 msgid "Posts"
 msgstr ""
 
-#: connectors/posts.php:67
-msgid "Edit %s"
-msgstr ""
-
-#: connectors/posts.php:74
-msgid "Revision"
+#: connectors/posts.php:95
+msgctxt "Post type singular name"
+msgid "Restore %s"
 msgstr ""
 
 #: connectors/posts.php:96
-msgid "\"%s\" %s drafted"
+msgctxt "Post type singular name"
+msgid "Delete %s Permenantly"
 msgstr ""
 
-#: connectors/posts.php:100 connectors/posts.php:104
-msgid "\"%s\" %s published"
+#: connectors/posts.php:98
+msgctxt "Post type singular name"
+msgid "Edit %s"
 msgstr ""
 
-#: connectors/posts.php:107
-msgid "\"%s\" %s unpublished"
+#: connectors/posts.php:105
+msgid "Revision"
 msgstr ""
 
-#: connectors/posts.php:110
-msgid "\"%s\" %s trashed"
+#: connectors/posts.php:126
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s drafted"
 msgstr ""
 
-#: connectors/posts.php:114 connectors/taxonomies.php:161
-msgid "\"%s\" %s updated"
+#: connectors/posts.php:133 connectors/posts.php:140
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s published"
 msgstr ""
 
-#: connectors/posts.php:172
-msgid "\"%s\" %s deleted from trash"
+#: connectors/posts.php:146
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s unpublished"
 msgstr ""
 
-#: connectors/settings.php:38 connectors/settings.php:59 includes/admin.php:99
-#: includes/admin.php:214
+#: connectors/posts.php:152
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s trashed"
+msgstr ""
+
+#: connectors/posts.php:159
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s restored from trash"
+msgstr ""
+
+#: connectors/posts.php:166
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s updated"
+msgstr ""
+
+#: connectors/posts.php:232
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s deleted from trash"
+msgstr ""
+
+#: connectors/posts.php:269
+msgid "Post"
+msgstr ""
+
+#: connectors/settings.php:94 connectors/settings.php:115
+#: includes/admin.php:129 includes/admin.php:316
 msgid "Settings"
 msgstr ""
 
-#: connectors/settings.php:60 includes/settings.php:56
+#: connectors/settings.php:116 includes/settings.php:241
 msgid "General"
 msgstr ""
 
-#: connectors/settings.php:61
+#: connectors/settings.php:117
 msgid "Writing"
 msgstr ""
 
-#: connectors/settings.php:62
+#: connectors/settings.php:118
 msgid "Reading"
 msgstr ""
 
-#: connectors/settings.php:63
+#: connectors/settings.php:119
 msgid "Discussion"
 msgstr ""
 
-#: connectors/settings.php:65
+#: connectors/settings.php:121
 msgid "Permalinks"
 msgstr ""
 
-#: connectors/settings.php:77
-msgid "Site Title"
+#: connectors/settings.php:122
+msgid "Network"
 msgstr ""
 
-#: connectors/settings.php:78
-msgid "Tagline"
-msgstr ""
-
-#: connectors/settings.php:79
-msgid "WordPress Address (URL)"
-msgstr ""
-
-#: connectors/settings.php:80
-msgid "Site Address (URL)"
-msgstr ""
-
-#: connectors/settings.php:81
-msgid "E-mail Address"
-msgstr ""
-
-#: connectors/settings.php:82
-msgid "Membership"
-msgstr ""
-
-#: connectors/settings.php:83
-msgid "New User Default Role"
-msgstr ""
-
-#: connectors/settings.php:84
-msgid "Timezone"
-msgstr ""
-
-#: connectors/settings.php:85
-msgid "Date Format"
-msgstr ""
-
-#: connectors/settings.php:86
-msgid "Time Format"
-msgstr ""
-
-#: connectors/settings.php:87
-msgid "Week Starts On"
-msgstr ""
-
-#: connectors/settings.php:89 connectors/settings.php:90
-msgid "Formatting"
-msgstr ""
-
-#: connectors/settings.php:91
-msgid "Default Post Category"
-msgstr ""
-
-#: connectors/settings.php:92
-msgid "Default Post Format"
-msgstr ""
-
-#: connectors/settings.php:93
-msgid "Mail Server Address"
-msgstr ""
-
-#: connectors/settings.php:94
-msgid "Mail Server Login Name"
-msgstr ""
-
-#: connectors/settings.php:95
-msgid "Mail Server Password"
-msgstr ""
-
-#: connectors/settings.php:96
-msgid "Default Mail Category"
-msgstr ""
-
-#: connectors/settings.php:97
-msgid "Update Services"
-msgstr ""
-
-#: connectors/settings.php:99 connectors/settings.php:100
-#: connectors/settings.php:101
-msgid "Front page displays"
-msgstr ""
-
-#: connectors/settings.php:102
-msgid "Blog pages show at most"
-msgstr ""
-
-#: connectors/settings.php:103
-msgid "Syndication feeds show the most recent"
-msgstr ""
-
-#: connectors/settings.php:104
-msgid "For each article in a feed, show"
-msgstr ""
-
-#: connectors/settings.php:105
-msgid "Search Engine Visibility"
-msgstr ""
-
-#: connectors/settings.php:107 connectors/settings.php:108
-#: connectors/settings.php:109
-msgid "Default article settings"
-msgstr ""
-
-#: connectors/settings.php:110 connectors/settings.php:111
-#: connectors/settings.php:112 connectors/settings.php:113
-#: connectors/settings.php:114 connectors/settings.php:115
-#: connectors/settings.php:116 connectors/settings.php:117
-#: connectors/settings.php:118 connectors/settings.php:119
-msgid "Other comment settings"
-msgstr ""
-
-#: connectors/settings.php:120 connectors/settings.php:121
-msgid "E-mail me whenever"
-msgstr ""
-
-#: connectors/settings.php:122 connectors/settings.php:123
-msgid "Before a comment appears"
-msgstr ""
-
-#: connectors/settings.php:124 connectors/settings.php:125
-msgid "Comment Moderation"
-msgstr ""
-
-#: connectors/settings.php:126
-msgid "Comment Blacklist"
-msgstr ""
-
-#: connectors/settings.php:127
-msgid "Avatar Display"
-msgstr ""
-
-#: connectors/settings.php:128
-msgid "Avatar Maximum Rating"
-msgstr ""
-
-#: connectors/settings.php:129
-msgid "Default Avatar"
-msgstr ""
-
-#: connectors/settings.php:131 connectors/settings.php:132
-#: connectors/settings.php:133
-msgid "Thumbnail Image Size"
-msgstr ""
-
-#: connectors/settings.php:134 connectors/settings.php:135
-msgid "Medium Image Size"
-msgstr ""
-
-#: connectors/settings.php:136 connectors/settings.php:137
-msgid "Large Image Size"
-msgstr ""
-
-#: connectors/settings.php:138
-msgid "Uploading Files Organization"
-msgstr ""
-
-#: connectors/settings.php:140
-msgid "Permalink structure"
-msgstr ""
-
-#: connectors/settings.php:141
-msgid "Category base"
-msgstr ""
-
-#: connectors/settings.php:142
-msgid "Tag base"
-msgstr ""
-
-#: connectors/settings.php:174
-msgid "Edit %s Settings"
-msgstr ""
-
-#: connectors/settings.php:255
-msgid "\"%s\" setting was updated"
-msgstr ""
-
-#: connectors/taxonomies.php:54
-msgid "Taxonomies"
-msgstr ""
-
-#: connectors/taxonomies.php:113
-msgid "\"%s\" %s created"
-msgstr ""
-
-#: connectors/taxonomies.php:133
-msgid "\"%s\" %s deleted"
-msgstr ""
-
-#: connectors/users.php:42 connectors/users.php:70
-msgid "Users"
-msgstr ""
-
-#: connectors/users.php:55
-msgid "Password Reset"
-msgstr ""
-
-#: connectors/users.php:56
-msgid "Forgot Password"
-msgstr ""
-
-#: connectors/users.php:57
-msgid "Login"
-msgstr ""
-
-#: connectors/users.php:58
-msgid "Logout"
-msgstr ""
-
-#: connectors/users.php:59
-msgid "Failed Login"
-msgstr ""
-
-#: connectors/users.php:85
-msgid "Edit Profile"
-msgstr ""
-
-#: connectors/users.php:131
-msgid "New user registration"
-msgstr ""
-
-#: connectors/users.php:134
-msgid "New user account created for %s (%s)"
-msgstr ""
-
-#: connectors/users.php:159
-msgid "%s's profile was updated"
-msgstr ""
-
-#: connectors/users.php:182
-msgid "%s's role was changed from %s to %s"
-msgstr ""
-
-#: connectors/users.php:202
-msgid "%s's password was reset"
-msgstr ""
-
-#: connectors/users.php:226
-msgid "%s's password was requested to be reset"
-msgstr ""
-
-#: connectors/users.php:246
-msgid "%s logged in"
-msgstr ""
-
-#: connectors/users.php:271
-msgid "%s logged out"
-msgstr ""
-
-#: connectors/users.php:309
-msgid "%s's account was deleted (%s)"
-msgstr ""
-
-#: connectors/users.php:314
-msgid "User account #%d was deleted"
-msgstr ""
-
-#: connectors/users.php:342
-msgid "Invalid login attempt for %s"
-msgstr ""
-
-#: connectors/widgets.php:28 connectors/widgets.php:53
-msgid "Widgets"
-msgstr ""
-
-#: connectors/widgets.php:38
-msgid "Added"
-msgstr ""
-
-#: connectors/widgets.php:42
-msgid "Sorted"
-msgstr ""
-
-#: connectors/widgets.php:69
-msgid "Edit Widget Area"
-msgstr ""
-
-#: connectors/widgets.php:95
-msgid "\"%s\" from \"%s\" has been deactivated"
-msgstr ""
-
-#: connectors/widgets.php:131
-msgid "\"%s\" has been added to \"%s\""
-msgstr ""
-
-#: connectors/widgets.php:138
-msgid "\"%s\" has been deleted from \"%s\""
-msgstr ""
-
-#: connectors/widgets.php:187
-msgid "Updated \"%s\" in \"%s\""
-msgstr ""
-
-#: connectors/widgets.php:234
-msgid "\"%s\" widgets were reordered"
-msgstr ""
-
-#: includes/admin.php:74
-msgid "All records have been successfully erased."
-msgstr ""
-
-#. #-#-#-#-#  stream.pot (Stream 1.0.3)  #-#-#-#-#
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
 #. Plugin Name of the plugin/theme
-#: includes/admin.php:87 includes/admin.php:88
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
+#. Author of the plugin/theme
+#: connectors/settings.php:123 includes/admin.php:117 includes/admin.php:118
+#: includes/network.php:72 includes/network.php:157
 msgid "Stream"
 msgstr ""
 
-#: includes/admin.php:98 includes/admin.php:238
+#: connectors/settings.php:124
+msgid "Custom Background"
+msgstr ""
+
+#: connectors/settings.php:125
+msgid "Custom Header"
+msgstr ""
+
+#: connectors/settings.php:132
+msgid "Stream Network"
+msgstr ""
+
+#: connectors/settings.php:133
+msgid "Stream Defaults"
+msgstr ""
+
+#: connectors/settings.php:202
+msgid "Site Title"
+msgstr ""
+
+#: connectors/settings.php:203
+msgid "Tagline"
+msgstr ""
+
+#: connectors/settings.php:204
+msgid "WordPress Address (URL)"
+msgstr ""
+
+#: connectors/settings.php:205
+msgid "Site Address (URL)"
+msgstr ""
+
+#: connectors/settings.php:206
+msgid "E-mail Address"
+msgstr ""
+
+#: connectors/settings.php:207
+msgid "Membership"
+msgstr ""
+
+#: connectors/settings.php:208
+msgid "New User Default Role"
+msgstr ""
+
+#: connectors/settings.php:209
+msgid "Timezone"
+msgstr ""
+
+#: connectors/settings.php:210
+msgid "Date Format"
+msgstr ""
+
+#: connectors/settings.php:211
+msgid "Time Format"
+msgstr ""
+
+#: connectors/settings.php:212
+msgid "Week Starts On"
+msgstr ""
+
+#: connectors/settings.php:214 connectors/settings.php:215
+msgid "Formatting"
+msgstr ""
+
+#: connectors/settings.php:216
+msgid "Default Post Category"
+msgstr ""
+
+#: connectors/settings.php:217
+msgid "Default Post Format"
+msgstr ""
+
+#: connectors/settings.php:218
+msgid "Mail Server"
+msgstr ""
+
+#: connectors/settings.php:219
+msgid "Login Name"
+msgstr ""
+
+#: connectors/settings.php:220
+msgid "Password"
+msgstr ""
+
+#: connectors/settings.php:221
+msgid "Default Mail Category"
+msgstr ""
+
+#: connectors/settings.php:222
+msgid "Update Services"
+msgstr ""
+
+#: connectors/settings.php:224 connectors/settings.php:225
+#: connectors/settings.php:226
+msgid "Front page displays"
+msgstr ""
+
+#: connectors/settings.php:227
+msgid "Blog pages show at most"
+msgstr ""
+
+#: connectors/settings.php:228
+msgid "Syndication feeds show the most recent"
+msgstr ""
+
+#: connectors/settings.php:229
+msgid "For each article in a feed, show"
+msgstr ""
+
+#: connectors/settings.php:230
+msgid "Search Engine Visibility"
+msgstr ""
+
+#: connectors/settings.php:232 connectors/settings.php:233
+#: connectors/settings.php:234
+msgid "Default article settings"
+msgstr ""
+
+#: connectors/settings.php:235 connectors/settings.php:236
+#: connectors/settings.php:237 connectors/settings.php:238
+#: connectors/settings.php:239 connectors/settings.php:240
+#: connectors/settings.php:241 connectors/settings.php:242
+#: connectors/settings.php:243 connectors/settings.php:244
+msgid "Other comment settings"
+msgstr ""
+
+#: connectors/settings.php:245 connectors/settings.php:246
+msgid "E-mail me whenever"
+msgstr ""
+
+#: connectors/settings.php:247 connectors/settings.php:248
+msgid "Before a comment appears"
+msgstr ""
+
+#: connectors/settings.php:249 connectors/settings.php:250
+msgid "Comment Moderation"
+msgstr ""
+
+#: connectors/settings.php:251
+msgid "Comment Blacklist"
+msgstr ""
+
+#: connectors/settings.php:252
+msgid "Show Avatars"
+msgstr ""
+
+#: connectors/settings.php:253
+msgid "Maximum Rating"
+msgstr ""
+
+#: connectors/settings.php:254
+msgid "Default Avatar"
+msgstr ""
+
+#: connectors/settings.php:256 connectors/settings.php:257
+#: connectors/settings.php:258
+msgid "Thumbnail size"
+msgstr ""
+
+#: connectors/settings.php:259 connectors/settings.php:260
+msgid "Medium size"
+msgstr ""
+
+#: connectors/settings.php:261 connectors/settings.php:262
+msgid "Large size"
+msgstr ""
+
+#: connectors/settings.php:263
+msgid "Uploading Files"
+msgstr ""
+
+#: connectors/settings.php:265
+msgid "Permalink Settings"
+msgstr ""
+
+#: connectors/settings.php:266
+msgid "Category base"
+msgstr ""
+
+#: connectors/settings.php:267
+msgid "Tag base"
+msgstr ""
+
+#: connectors/settings.php:269
+msgid "Registration notification"
+msgstr ""
+
+#: connectors/settings.php:270
+msgid "Allow new registrations"
+msgstr ""
+
+#: connectors/settings.php:271
+msgid "Add New Users"
+msgstr ""
+
+#: connectors/settings.php:272
+msgid "Enable administration menus"
+msgstr ""
+
+#: connectors/settings.php:273
+msgid "Site upload space check"
+msgstr ""
+
+#: connectors/settings.php:274
+msgid "Site upload space"
+msgstr ""
+
+#: connectors/settings.php:275
+msgid "Upload file types"
+msgstr ""
+
+#: connectors/settings.php:276
+msgid "Network Title"
+msgstr ""
+
+#: connectors/settings.php:277
+msgid "First Post"
+msgstr ""
+
+#: connectors/settings.php:278
+msgid "First Page"
+msgstr ""
+
+#: connectors/settings.php:279
+msgid "First Comment"
+msgstr ""
+
+#: connectors/settings.php:280
+msgid "First Comment URL"
+msgstr ""
+
+#: connectors/settings.php:281
+msgid "First Comment Author"
+msgstr ""
+
+#: connectors/settings.php:282
+msgid "Welcome Email"
+msgstr ""
+
+#: connectors/settings.php:283
+msgid "Welcome User Email"
+msgstr ""
+
+#: connectors/settings.php:284
+msgid "Max upload file size"
+msgstr ""
+
+#: connectors/settings.php:285
+msgid "Terms Enabled"
+msgstr ""
+
+#: connectors/settings.php:286
+msgid "Banned Names"
+msgstr ""
+
+#: connectors/settings.php:287
+msgid "Limited Email Registrations"
+msgstr ""
+
+#: connectors/settings.php:288
+msgid "Banned Email Domains"
+msgstr ""
+
+#: connectors/settings.php:289
+msgid "Network Language"
+msgstr ""
+
+#: connectors/settings.php:290
+msgid "Network Admin Email"
+msgstr ""
+
+#: connectors/settings.php:292
+msgid "Stream Database Version"
+msgstr ""
+
+#: connectors/settings.php:321
+msgid "Background Image"
+msgstr ""
+
+#: connectors/settings.php:322
+msgid "Background Position"
+msgstr ""
+
+#: connectors/settings.php:323
+msgid "Background Repeat"
+msgstr ""
+
+#: connectors/settings.php:324
+msgid "Background Attachment"
+msgstr ""
+
+#: connectors/settings.php:325
+msgid "Background Color"
+msgstr ""
+
+#: connectors/settings.php:327
+msgid "Header Image"
+msgstr ""
+
+#: connectors/settings.php:328
+msgid "Text Color"
+msgstr ""
+
+#: connectors/settings.php:461
+msgid "Edit %s Settings"
+msgstr ""
+
+#: connectors/settings.php:595
+msgid "\"%s\" setting was updated"
+msgstr ""
+
+#: connectors/taxonomies.php:53
+msgid "Taxonomies"
+msgstr ""
+
+#: connectors/taxonomies.php:98
+msgctxt "Term singular name"
+msgid "Edit %s"
+msgstr ""
+
+#: connectors/taxonomies.php:124
+msgctxt "1: Term name, 2: Taxonomy singular label"
+msgid "\"%1$s\" %2$s created"
+msgstr ""
+
+#: connectors/taxonomies.php:152
+msgctxt "1: Term name, 2: Taxonomy singular label"
+msgid "\"%1$s\" %2$s deleted"
+msgstr ""
+
+#: connectors/taxonomies.php:190
+msgctxt "1: Term name, 2: Taxonomy singular label"
+msgid "\"%1$s\" %2$s updated"
+msgstr ""
+
+#: connectors/users.php:43 connectors/users.php:70
+msgid "Users"
+msgstr ""
+
+#: connectors/users.php:56
+msgid "Password Reset"
+msgstr ""
+
+#: connectors/users.php:57
+msgid "Lost Password"
+msgstr ""
+
+#: connectors/users.php:58
+msgid "Log In"
+msgstr ""
+
+#: connectors/users.php:59
+msgid "Log Out"
+msgstr ""
+
+#: connectors/users.php:71
+msgid "Sessions"
+msgstr ""
+
+#: connectors/users.php:72
+msgid "Profiles"
+msgstr ""
+
+#: connectors/users.php:87
+msgid "Edit User"
+msgstr ""
+
+#: connectors/users.php:134
+msgid "New user registration"
+msgstr ""
+
+#: connectors/users.php:137
+msgctxt "1: User display name, 2: User role"
+msgid "New user account created for %1$s (%2$s)"
+msgstr ""
+
+#: connectors/users.php:164
+msgid "%s's profile was updated"
+msgstr ""
+
+#: connectors/users.php:186
+msgctxt "1: User display name, 2: Old role, 3: New role"
+msgid "%1$s's role was changed from %2$s to %3$s"
+msgstr ""
+
+#: connectors/users.php:208
+msgid "%s's password was reset"
+msgstr ""
+
+#: connectors/users.php:231
+msgid "%s's password was requested to be reset"
+msgstr ""
+
+#: connectors/users.php:249
+msgid "%s logged in"
+msgstr ""
+
+#: connectors/users.php:272
+msgid "%s logged out"
+msgstr ""
+
+#: connectors/users.php:306
+msgctxt "1: User display name, 2: User roles"
+msgid "%1$s's account was deleted (%2$s)"
+msgstr ""
+
+#: connectors/users.php:315
+msgid "User account #%d was deleted"
+msgstr ""
+
+#: connectors/widgets.php:30 connectors/widgets.php:269
+#: connectors/widgets.php:316
+msgid "Widgets"
+msgstr ""
+
+#: connectors/widgets.php:40
+msgid "Added"
+msgstr ""
+
+#: connectors/widgets.php:44
+msgid "Sorted"
+msgstr ""
+
+#: connectors/widgets.php:62
+msgid "Inactive Widgets"
+msgstr ""
+
+#: connectors/widgets.php:80
+msgid "Edit Widget Area"
+msgstr ""
+
+#: connectors/widgets.php:109
+msgctxt "1: Widget title"
+msgid "\"%1$s\" has been deactivated"
+msgstr ""
+
+#: connectors/widgets.php:153
+msgctxt "1: Widget title, 2: Sidebar name"
+msgid "\"%1$s\" has been added to \"%2$s\""
+msgstr ""
+
+#: connectors/widgets.php:164
+msgctxt "1: Widget title, 2: Sidebar name"
+msgid "\"%1$s\" has been deleted from \"%2$s\""
+msgstr ""
+
+#: connectors/widgets.php:221
+msgctxt "1: Widget title, 2: Sidebar name"
+msgid "\"%1$s\" in \"%2$s\" updated"
+msgstr ""
+
+#: connectors/widgets.php:275
+msgctxt "Sidebar name"
+msgid "Widgets in \"%s\" were reordered"
+msgstr ""
+
+#: includes/admin.php:93
+msgid "All records have been successfully erased."
+msgstr ""
+
+#: includes/admin.php:96
+msgid "All site settings have been successfully reset."
+msgstr ""
+
+#: includes/admin.php:128
 msgid "Stream Settings"
 msgstr ""
 
-#: includes/admin.php:136
+#: includes/admin.php:138 includes/extensions.php:159
+#: includes/extensions.php:226 includes/extensions.php:260
+#: includes/network.php:148 includes/network.php:156 includes/pointers.php:144
+msgid "Stream Extensions"
+msgstr ""
+
+#: includes/admin.php:139 includes/network.php:149
+msgid "Extensions"
+msgstr ""
+
+#: includes/admin.php:196
 msgid ""
 "Are you sure you want to delete all Stream activity records from the "
 "database? This cannot be undone."
 msgstr ""
 
-#: includes/admin.php:137
+#: includes/admin.php:197
+msgid ""
+"Are you sure you want to reset all site settings to default? This cannot be "
+"undone."
+msgstr ""
+
+#: includes/admin.php:198
 msgid ""
 "Are you sure you want to uninstall and deactivate Stream? This will delete "
 "all Stream tables from the database and cannot be undone."
 msgstr ""
 
-#: includes/admin.php:223
+#: includes/admin.php:325
 msgid "Uninstall"
 msgstr ""
 
-#: includes/admin.php:287
+#: includes/admin.php:478
+msgid "Connected"
+msgstr ""
+
+#: includes/admin.php:479 includes/extensions.php:229
+msgid "Connect to Stream Extensions"
+msgstr ""
+
+#: includes/admin.php:501
+msgid "Return to Stream Extensions"
+msgstr ""
+
+#: includes/admin.php:514 includes/admin.php:520 includes/admin.php:522
 msgid "Stream Records"
 msgstr ""
 
-#: includes/admin.php:450
+#: includes/admin.php:519
+msgid "1 site"
+msgid_plural "%d sites"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin.php:823
+msgid "One more result..."
+msgid_plural "%d more results..."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/class-wp-stream-author.php:61
+#: includes/class-wp-stream-author.php:69
+msgid "N/A"
+msgstr ""
+
+#: includes/class-wp-stream-author.php:234
+msgid "via WP-CLI"
+msgstr ""
+
+#: includes/class-wp-stream-author.php:236
+msgid "during WP Cron"
+msgstr ""
+
+#: includes/connectors.php:90
+msgid "%s class wasn't loaded because it doesn't extends the %s class."
+msgstr ""
+
+#: includes/dashboard.php:25
+msgid "Network Stream Activity"
+msgstr ""
+
+#: includes/dashboard.php:25
 msgid "Stream Activity"
 msgstr ""
 
-#: includes/admin.php:469
+#: includes/dashboard.php:57
 msgid "Sorry, no activity records were found."
 msgstr ""
 
-#: includes/admin.php:497
-msgid "ago by"
+#: includes/dashboard.php:106
+msgid "View all records"
 msgstr ""
 
-#: includes/admin.php:503 includes/list-table.php:134
-msgid "%s ago"
+#: includes/dashboard.php:108
+msgid "View All"
 msgstr ""
 
-#: includes/admin.php:528
-msgid "View all Stream Records"
+#: includes/dashboard.php:126
+msgid "Go to the first page"
 msgstr ""
 
-#: includes/admin.php:529
-msgid "More"
+#: includes/dashboard.php:134
+msgid "Go to the previous page"
 msgstr ""
 
-#: includes/admin.php:551
-msgid "Number of Records"
+#: includes/dashboard.php:141
+msgctxt "paging"
+msgid "%1$s of %2$s"
 msgstr ""
 
-#: includes/feeds.php:73
+#: includes/dashboard.php:146
+msgid "Go to the next page"
+msgstr ""
+
+#: includes/dashboard.php:155
+msgid "Go to the last page"
+msgstr ""
+
+#: includes/dashboard.php:192 includes/list-table.php:22
+msgid "Records per page"
+msgstr ""
+
+#: includes/dashboard.php:197
+msgid "Enable live updates"
+msgstr ""
+
+#: includes/dashboard.php:217
+msgctxt "1: Time, 2: User profile URL, 3: User display name"
+msgid "%1$s ago by <a href=\"%2$s\">%3$s</a>"
+msgstr ""
+
+#: includes/date-interval.php:51
+msgid "Today"
+msgstr ""
+
+#: includes/date-interval.php:56
+msgid "Yesterday"
+msgstr ""
+
+#: includes/date-interval.php:61 includes/date-interval.php:66
+#: includes/date-interval.php:71
+msgid "Last %d Days"
+msgstr ""
+
+#: includes/date-interval.php:76
+msgid "This Month"
+msgstr ""
+
+#: includes/date-interval.php:80
+msgid "Last Month"
+msgstr ""
+
+#: includes/date-interval.php:85 includes/date-interval.php:90
+#: includes/date-interval.php:95
+msgid "Last %d Months"
+msgstr ""
+
+#: includes/date-interval.php:100
+msgid "This Year"
+msgstr ""
+
+#: includes/date-interval.php:104
+msgid "Last Year"
+msgstr ""
+
+#: includes/db-updates.php:110 includes/db-updates.php:204
+#: includes/db-updates.php:226 includes/db-updates.php:490
+#: includes/db-updates.php:518 includes/db-updates.php:555
+msgid "Database Update Error"
+msgstr ""
+
+#: includes/deprecated.php:55
+msgid "The %s filter"
+msgstr ""
+
+#: includes/extensions.php:159
+msgid "You must connect to your %s account to install extensions."
+msgstr ""
+
+#: includes/extensions.php:159
+msgid "Don't have an account?"
+msgstr ""
+
+#: includes/extensions.php:159 includes/extensions.php:239
+msgid "Join Stream Extensions"
+msgstr ""
+
+#: includes/extensions.php:231
+msgid "Disconnect"
+msgstr ""
+
+#: includes/extensions.php:238
+msgid ""
+"Connect your Stream Extensions account and authorize this domain to install "
+"and receive automatic updates for premium extensions. Don't have an account?"
+msgstr ""
+
+#: includes/extensions.php:243
+msgid "Your account is connected!"
+msgstr ""
+
+#: includes/extensions.php:262
+msgid "Sorry, there was a problem loading the list of extensions."
+msgstr ""
+
+#: includes/extensions.php:264
+msgid "Browse All Extensions"
+msgstr ""
+
+#: includes/extensions.php:306
+msgid "View Details"
+msgstr ""
+
+#: includes/extensions.php:310
+msgid "Inactive"
+msgstr ""
+
+#: includes/extensions.php:318
+msgid "Get This Extension"
+msgstr ""
+
+#: includes/extensions.php:322 includes/extensions.php:375
+msgid "Install Now"
+msgstr ""
+
+#: includes/extensions.php:327 includes/extensions.php:376
+#: includes/updater.php:210
+msgid "Activate"
+msgstr ""
+
+#: includes/extensions.php:330 includes/extensions.php:377
+msgid "Active"
+msgstr ""
+
+#: includes/feeds.php:125
 msgid "Stream Feeds Key"
 msgstr ""
 
-#: includes/feeds.php:77
+#: includes/feeds.php:130
 msgid "Generate new key"
 msgstr ""
 
-#: includes/feeds.php:79
+#: includes/feeds.php:133
 msgid ""
 "This is your private key used for accessing feeds of Stream Records "
 "securely. You can change your key at any time by generating a new one using "
 "the link above."
 msgstr ""
 
-#: includes/feeds.php:81
+#: includes/feeds.php:135
 msgid "RSS Feed"
 msgstr ""
 
-#: includes/feeds.php:83
+#: includes/feeds.php:137
 msgid "JSON Feed"
 msgstr ""
 
-#: includes/feeds.php:97
+#: includes/feeds.php:185
 msgid "Access Denied"
 msgstr ""
 
-#: includes/feeds.php:98
+#: includes/feeds.php:186
 msgid ""
 "You don't have permission to view this feed, please contact your site "
 "Administrator."
 msgstr ""
 
-#: includes/feeds.php:160
+#: includes/feeds.php:270
 msgid "Stream Feed"
 msgstr ""
 
-#: includes/list-table.php:18
-msgid "Records per page"
+#: includes/filter-input.php:49
+msgid "Invalid use, type must be one of INPUT_* family."
 msgstr ""
 
-#: includes/list-table.php:38
+#: includes/filter-input.php:65
+msgid "Filter not supported."
+msgstr ""
+
+#: includes/install.php:172
+msgid "There was an error updating the Stream database. Please try again."
+msgstr ""
+
+#: includes/install.php:206
+msgid "Stream Database Update Required"
+msgstr ""
+
+#: includes/install.php:207
+msgid ""
+"Stream has updated! Before we send you on your way, we need to update your "
+"database to the newest version."
+msgstr ""
+
+#: includes/install.php:208
+msgid "This process could take a little while, so please be patient."
+msgstr ""
+
+#: includes/install.php:209
+msgid "Update Database"
+msgstr ""
+
+#: includes/install.php:227
+msgid "Update Complete"
+msgstr ""
+
+#: includes/install.php:229
+msgid "Continue"
+msgstr ""
+
+#: includes/list-table.php:53
 msgid "Date"
 msgstr ""
 
-#: includes/list-table.php:39
+#: includes/list-table.php:54
 msgid "Summary"
 msgstr ""
 
-#: includes/list-table.php:40
+#: includes/list-table.php:55
 msgid "Author"
 msgstr ""
 
-#: includes/list-table.php:41
+#: includes/list-table.php:56
 msgid "Connector"
 msgstr ""
 
-#: includes/list-table.php:42
+#: includes/list-table.php:57
 msgid "Context"
 msgstr ""
 
-#: includes/list-table.php:43
+#: includes/list-table.php:58
 msgid "Action"
 msgstr ""
 
-#: includes/list-table.php:44
+#: includes/list-table.php:59
 msgid "IP Address"
 msgstr ""
 
-#: includes/list-table.php:45
-msgid "ID"
+#: includes/list-table.php:60
+msgid "Record ID"
 msgstr ""
 
-#: includes/list-table.php:150
+#: includes/list-table.php:201
 msgid "View all records for this object"
 msgstr ""
 
-#: includes/list-table.php:301
+#: includes/list-table.php:218
+msgid "Deleted User"
+msgstr ""
+
+#: includes/list-table.php:484
+msgid "dates"
+msgstr ""
+
+#: includes/list-table.php:493
 msgid "authors"
 msgstr ""
 
-#: includes/list-table.php:309
+#: includes/list-table.php:499
 msgid "connectors"
 msgstr ""
 
-#: includes/list-table.php:317
+#: includes/list-table.php:504
 msgid "contexts"
 msgstr ""
 
-#: includes/list-table.php:325
+#: includes/list-table.php:509
 msgid "actions"
 msgstr ""
 
-#: includes/list-table.php:337
+#: includes/list-table.php:531
+msgid "Show filter controls via the screen options tab above."
+msgstr ""
+
+#: includes/list-table.php:541
 msgid "Filter"
 msgstr ""
 
-#: includes/list-table.php:343
-msgid "<option value=\"\"></option>"
-msgstr ""
-
-#: includes/list-table.php:356
+#: includes/list-table.php:573
 msgid "Show all %s"
 msgstr ""
 
-#: includes/list-table.php:369
+#: includes/list-table.php:588
 msgid "Search Records"
 msgstr ""
 
-#: includes/list-table.php:389
-msgid "Date start"
+#: includes/list-table.php:608
+msgid "All Time"
 msgstr ""
 
-#: includes/list-table.php:391
-msgid "Date end"
+#: includes/list-table.php:610
+msgid "Custom"
 msgstr ""
 
-#: includes/list-table.php:455
+#: includes/list-table.php:629
+msgid "Start Date"
+msgstr ""
+
+#: includes/list-table.php:639
+msgid "End Date"
+msgstr ""
+
+#: includes/list-table.php:713
 msgid "Live updates"
 msgstr ""
 
-#: includes/list-table.php:461 includes/settings.php:87
+#: includes/list-table.php:724 includes/network.php:291
+#: includes/settings.php:270
 msgid "Enabled"
 msgstr ""
 
-#: includes/settings.php:60
-msgid "Log Activity for"
+#: includes/live-update.php:115
+msgid "1 item"
+msgid_plural "%s items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/network.php:85
+msgid "Network Admin"
 msgstr ""
 
-#: includes/settings.php:62
-msgid "Only the selected roles above will have their activity logged."
+#: includes/network.php:128
+msgid "Stream Network Settings"
 msgstr ""
 
-#: includes/settings.php:68
+#: includes/network.php:129
+msgid "Network Settings"
+msgstr ""
+
+#: includes/network.php:138
+msgid "New Site Settings"
+msgstr ""
+
+#: includes/network.php:139
+msgid "Site Defaults"
+msgstr ""
+
+#: includes/network.php:213
+msgid "These settings apply to all sites on the network."
+msgstr ""
+
+#: includes/network.php:216
+msgid ""
+"These default settings will apply to new sites created on the network. These "
+"settings do not alter existing sites."
+msgstr ""
+
+#: includes/network.php:290
+msgid "Enable Site Access"
+msgstr ""
+
+#: includes/network.php:293
+msgid ""
+"When site access is disabled Stream can only be accessed from the network "
+"administration."
+msgstr ""
+
+#: includes/network.php:309
+msgid "Reset Site Settings"
+msgstr ""
+
+#: includes/network.php:312
+msgid "Warning: Clicking this will override all site settings with defaults."
+msgstr ""
+
+#: includes/network.php:396
+msgid "Settings saved."
+msgstr ""
+
+#: includes/network.php:454
+msgid "sites"
+msgstr ""
+
+#: includes/network.php:471 includes/network.php:521
+msgid "Site"
+msgstr ""
+
+#: includes/pointers.php:145
+msgid "Extension plugins are now available for Stream!"
+msgstr ""
+
+#: includes/settings.php:88
+msgid "There was an error in the request"
+msgstr ""
+
+#: includes/settings.php:134
+msgid ""
+"ID: %d\n"
+"User: %s\n"
+"Email: %s\n"
+"Role: %s"
+msgstr ""
+
+#: includes/settings.php:153
+msgid ""
+"Actions performed by the system when a user is not logged in (e.g. auto site "
+"upgrader, or invoking WP-CLI without --user)"
+msgstr ""
+
+#: includes/settings.php:245
 msgid "Role Access"
 msgstr ""
 
-#: includes/settings.php:70
+#: includes/settings.php:247
 msgid ""
 "Users from the selected roles above will have permission to view Stream "
 "Records. However, only site Administrators can access Stream Settings."
 msgstr ""
 
-#: includes/settings.php:76
+#: includes/settings.php:253
 msgid "Private Feeds"
 msgstr ""
 
-#: includes/settings.php:79
+#: includes/settings.php:256
 msgid ""
 "Users from the selected roles above will be given a private key found in "
-"their %suser profile%s to access feeds of Stream Records securely."
+"their %suser profile%s to access feeds of Stream Records securely. Please "
+"%sflush rewrite rules%s on your site after changing this setting."
 msgstr ""
 
-#: includes/settings.php:83
+#: includes/settings.php:260
 msgid "View Profile"
 msgstr ""
 
-#: includes/settings.php:92
+#: includes/settings.php:266
+msgid "View Codex"
+msgstr ""
+
+#: includes/settings.php:275
 msgid "Keep Records for"
 msgstr ""
 
-#: includes/settings.php:95
+#: includes/settings.php:278
 msgid ""
 "Maximum number of days to keep activity records. Leave blank to keep records "
 "forever."
 msgstr ""
 
-#: includes/settings.php:97
+#: includes/settings.php:280
 msgid "days"
 msgstr ""
 
-#: includes/settings.php:101
-msgid "Delete All Records"
+#: includes/settings.php:284
+msgid "Reset Stream Database"
 msgstr ""
 
-#: includes/settings.php:110
+#: includes/settings.php:293
 msgid ""
 "Warning: Clicking this will delete all activity records from the database."
 msgstr ""
 
-#: includes/settings.php:282
-msgid "Reset Stream Database"
+#: includes/settings.php:299
+msgid "Exclude"
 msgstr ""
 
-#: stream.php:166
-msgid "The following table is not present in the WordPress database :"
+#: includes/settings.php:303
+msgid "Authors &amp; Roles"
 msgstr ""
 
-#: stream.php:174
+#: includes/settings.php:305
+msgid "No activity will be logged for these authors and/or roles."
+msgstr ""
+
+#: includes/settings.php:311
+msgid "Connectors"
+msgstr ""
+
+#: includes/settings.php:313
+msgid "No activity will be logged for these connectors."
+msgstr ""
+
+#: includes/settings.php:320
+msgid "Contexts"
+msgstr ""
+
+#: includes/settings.php:322
+msgid "No activity will be logged for these contexts."
+msgstr ""
+
+#: includes/settings.php:329
+msgid "Actions"
+msgstr ""
+
+#: includes/settings.php:331
+msgid "No activity will be logged for these actions."
+msgstr ""
+
+#: includes/settings.php:338
+msgid "IP Addresses"
+msgstr ""
+
+#: includes/settings.php:340
+msgid "No activity will be logged for these IP addresses."
+msgstr ""
+
+#: includes/settings.php:347
+msgid "Visibility"
+msgstr ""
+
+#: includes/settings.php:350
+msgid ""
+"When checked, all past records that match the excluded rules above will be "
+"hidden from view."
+msgstr ""
+
+#: includes/settings.php:352
+msgid "Hide Previous Records"
+msgstr ""
+
+#: includes/settings.php:709
+msgid "1 user"
+msgid_plural "%s users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/updater.php:65 includes/updater.php:130
+msgid "Could not connect to Stream update center."
+msgstr ""
+
+#: includes/updater.php:151 includes/updater.php:186
+msgid "Invalid security check."
+msgstr ""
+
+#: includes/updater.php:166
+msgid "Could not connect to Stream license server to verify license details."
+msgstr ""
+
+#: includes/updater.php:196
+msgid "Site disconnected successfully from your Stream account."
+msgstr ""
+
+#: includes/updater.php:231
+msgid ""
+"You must subscribe to Stream &copy; to be able to download premium "
+"extensions."
+msgstr ""
+
+#: includes/updater.php:262
+msgid "Installing %s Stream extension."
+msgstr ""
+
+#: includes/updater.php:277
+msgid "Extension was downloaded and activated successfully!"
+msgstr ""
+
+#: stream.php:149
+msgid "Stream requires PHP version 5.3+, plugin is currently NOT ACTIVE."
+msgstr ""
+
+#: stream.php:211
+msgid "The following table is not present in the WordPress database:"
+msgid_plural "The following tables are not present in the WordPress database:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: stream.php:222 stream.php:224
 msgid ""
 "Please <a href=\"%s\">uninstall</a> the Stream plugin and activate it again."
 msgstr ""
 
-#: stream.php:188
-msgid "Stream requires PHP version 5.3+, plugin is currently NOT ACTIVE."
-msgstr ""
-
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
 #. Plugin URI of the plugin/theme
-msgid "http://wordpress.org/plugins/stream/"
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
+#. Author URI of the plugin/theme
+msgid "https://wp-stream.com/"
 msgstr ""
 
 #. Description of the plugin/theme
@@ -945,12 +1714,4 @@ msgid ""
 "on your WordPress site in beautifully organized detail. All activity is "
 "organized by context, action and IP address for easy filtering. Developers "
 "can extend Stream with custom connectors to log any kind of action."
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "X-Team"
-msgstr ""
-
-#. Author URI of the plugin/theme
-msgid "http://x-team.com/wordpress/"
 msgstr ""

--- a/languages/stream.pot
+++ b/languages/stream.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Stream package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Stream 1.0.3\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tag/stream\n"
-"POT-Creation-Date: 2014-01-21 19:44:03+00:00\n"
+"Project-Id-Version: Stream 1.4.6\n"
+"Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/wp-stream\n"
+"POT-Creation-Date: 2014-06-25 02:57:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,633 +12,945 @@ msgstr ""
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
-#: connectors/comments.php:34 connectors/comments.php:66
-msgid "Comments"
+#: connectors/blogs.php:39
+msgid "Sites"
 msgstr ""
 
-#: connectors/comments.php:44 connectors/menus.php:37 connectors/posts.php:37
+#: connectors/blogs.php:49 connectors/editor.php:53
+#: connectors/installer.php:50 connectors/media.php:43 connectors/menus.php:40
+#: connectors/posts.php:38 connectors/settings.php:104
 #: connectors/taxonomies.php:64 connectors/users.php:53
+#: connectors/widgets.php:43
+msgid "Updated"
+msgstr ""
+
+#: connectors/blogs.php:50 connectors/comments.php:46 connectors/menus.php:39
+#: connectors/posts.php:39 connectors/taxonomies.php:63
+#: connectors/users.php:54
 msgid "Created"
 msgstr ""
 
-#: connectors/comments.php:45 connectors/installer.php:47
-msgid "Edited"
+#: connectors/blogs.php:51
+msgid "Archived"
 msgstr ""
 
-#: connectors/comments.php:46
-msgid "Replied"
-msgstr ""
-
-#: connectors/comments.php:47
-msgid "Approved"
-msgstr ""
-
-#: connectors/comments.php:48
-msgid "Unapproved"
-msgstr ""
-
-#: connectors/comments.php:49 connectors/posts.php:38
-msgid "Trashed"
-msgstr ""
-
-#: connectors/comments.php:50
-msgid "Restored"
-msgstr ""
-
-#: connectors/comments.php:51
-msgid "Marked as Spam"
-msgstr ""
-
-#: connectors/comments.php:52
-msgid "Unmarked as Spam"
-msgstr ""
-
-#: connectors/comments.php:53 connectors/installer.php:46
-#: connectors/media.php:42 connectors/menus.php:39 connectors/posts.php:39
-#: connectors/taxonomies.php:66 connectors/users.php:54
-#: connectors/widgets.php:39
+#: connectors/blogs.php:52 connectors/comments.php:55
+#: connectors/installer.php:48 connectors/media.php:44 connectors/menus.php:41
+#: connectors/posts.php:42 connectors/taxonomies.php:65
+#: connectors/users.php:55 connectors/widgets.php:41
 msgid "Deleted"
 msgstr ""
 
+#: connectors/blogs.php:83 connectors/blogs.php:88
+msgid "Site Admin"
+msgstr ""
+
+#: connectors/blogs.php:99
+msgid "Site Settings"
+msgstr ""
+
+#: connectors/blogs.php:113
+msgctxt "1. Site name"
+msgid "A new site called \"%1$s\" has been created."
+msgstr ""
+
+#: connectors/blogs.php:135
+msgctxt "1. Site name"
+msgid "A new site called \"%1$s\" has been registered."
+msgstr ""
+
+#: connectors/blogs.php:165
+msgctxt "1. User's name, 2. Site name, 3. Role"
+msgid "%1$s has been added to the site \"%2$s\" with %3$s capabilities."
+msgstr ""
+
+#: connectors/blogs.php:195
+msgctxt "1. User's name, 2. Site name"
+msgid "%1$s has been removed from the site \"%2$s\"."
+msgstr ""
+
+#: connectors/blogs.php:214
+msgid "marked as spam"
+msgstr ""
+
+#: connectors/blogs.php:222
+msgid "marked as not spam"
+msgstr ""
+
+#: connectors/blogs.php:230
+msgid "marked as mature"
+msgstr ""
+
+#: connectors/blogs.php:238
+msgid "marked as not mature"
+msgstr ""
+
+#: connectors/blogs.php:246
+msgid "archived"
+msgstr ""
+
+#: connectors/blogs.php:254
+msgid "restored from archive"
+msgstr ""
+
+#: connectors/blogs.php:262
+msgid "deleted"
+msgstr ""
+
+#: connectors/blogs.php:270
+msgid "restored"
+msgstr ""
+
+#: connectors/blogs.php:280
+msgid "marked as public"
+msgstr ""
+
+#: connectors/blogs.php:282
+msgid "marked as private"
+msgstr ""
+
+#: connectors/blogs.php:295
+msgctxt "1. Site name, 2. Status"
+msgid "\"%1$s\" has been %2$s."
+msgstr ""
+
+#: connectors/comments.php:36 connectors/comments.php:68
+msgid "Comments"
+msgstr ""
+
+#: connectors/comments.php:47 connectors/installer.php:49
+msgid "Edited"
+msgstr ""
+
+#: connectors/comments.php:48
+msgid "Replied"
+msgstr ""
+
+#: connectors/comments.php:49
+msgid "Approved"
+msgstr ""
+
+#: connectors/comments.php:50
+msgid "Unapproved"
+msgstr ""
+
+#: connectors/comments.php:51 connectors/posts.php:40
+msgid "Trashed"
+msgstr ""
+
+#: connectors/comments.php:52 connectors/posts.php:41
+msgid "Restored"
+msgstr ""
+
+#: connectors/comments.php:53
+msgid "Marked as Spam"
+msgstr ""
+
 #: connectors/comments.php:54
+msgid "Unmarked as Spam"
+msgstr ""
+
+#: connectors/comments.php:56
 msgid "Duplicate"
 msgstr ""
 
-#: connectors/comments.php:55
+#: connectors/comments.php:57
 msgid "Throttled"
 msgstr ""
 
-#: connectors/comments.php:84 connectors/taxonomies.php:93
+#: connectors/comments.php:86
 msgid "Edit"
 msgstr ""
 
-#: connectors/comments.php:86
+#: connectors/comments.php:89
 msgid "Unapprove"
 msgstr ""
 
-#: connectors/comments.php:94
+#: connectors/comments.php:97
 msgid "Approve"
 msgstr ""
 
-#: connectors/comments.php:125
+#: connectors/comments.php:129
 msgid "Guest"
 msgstr ""
 
-#: connectors/comments.php:161
+#: connectors/comments.php:165
 msgid "a logged out user"
 msgstr ""
 
-#: connectors/comments.php:165
+#: connectors/comments.php:169
 msgid "Comment flooding by %s detected and prevented"
 msgstr ""
 
-#: connectors/comments.php:181 connectors/comments.php:224
-#: connectors/comments.php:248 connectors/comments.php:272
-#: connectors/comments.php:296 connectors/comments.php:320
-#: connectors/comments.php:344 connectors/comments.php:371
-#: connectors/comments.php:398
+#: connectors/comments.php:190 connectors/comments.php:239
+#: connectors/comments.php:269 connectors/comments.php:299
+#: connectors/comments.php:329 connectors/comments.php:359
+#: connectors/comments.php:389 connectors/comments.php:421
+#: connectors/comments.php:454
 msgid "a post"
 msgstr ""
 
-#: connectors/comments.php:182
+#: connectors/comments.php:191
 msgid "approved automatically"
 msgstr ""
 
-#: connectors/comments.php:182
+#: connectors/comments.php:191
 msgid "pending approval"
 msgstr ""
 
-#: connectors/comments.php:189
+#: connectors/comments.php:198
 msgctxt ""
 "1: Parent comment's author, 2: Comment author, 3: Post title, 4: Comment "
 "status"
 msgid "Reply to %1$s's comment by %2$s on %3$s %4$s"
 msgstr ""
 
-#: connectors/comments.php:201
+#: connectors/comments.php:210
 msgctxt "1: Comment author, 2: Post title 3: Comment status"
 msgid "New comment by %1$s on %2$s %3$s"
 msgstr ""
 
-#: connectors/comments.php:227
+#: connectors/comments.php:242
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s edited"
 msgstr ""
 
-#: connectors/comments.php:251
+#: connectors/comments.php:272
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s deleted permanently"
 msgstr ""
 
-#: connectors/comments.php:275
+#: connectors/comments.php:302
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s trashed"
 msgstr ""
 
-#: connectors/comments.php:299
+#: connectors/comments.php:332
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s restored"
 msgstr ""
 
-#: connectors/comments.php:323
+#: connectors/comments.php:362
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s marked as spam"
 msgstr ""
 
-#: connectors/comments.php:347
+#: connectors/comments.php:392
 msgctxt "1: Comment author, 2: Post title"
 msgid "%1$s's comment on %2$s unmarked as spam"
 msgstr ""
 
-#: connectors/comments.php:374
+#: connectors/comments.php:424
 msgctxt "Comment status transition. 1: Comment author, 2: Post title"
 msgid "%1$s's comment %2$s"
 msgstr ""
 
-#: connectors/comments.php:401
+#: connectors/comments.php:457
 msgctxt "1: Comment author, 2: Post title"
 msgid "Duplicate comment by %1$s prevented on %2$s"
 msgstr ""
 
-#: connectors/installer.php:33
+#: connectors/editor.php:43
+msgid "Theme Editor"
+msgstr ""
+
+#: connectors/editor.php:83
+msgid "\"%1$s\" in \"%2$s\" updated"
+msgstr ""
+
+#: connectors/editor.php:100
+msgid "Edit File"
+msgstr ""
+
+#: connectors/editor.php:108
+msgid "Edit Theme"
+msgstr ""
+
+#: connectors/installer.php:35
 msgid "Installer"
 msgstr ""
 
-#: connectors/installer.php:43
+#: connectors/installer.php:45
 msgid "Installed"
 msgstr ""
 
-#: connectors/installer.php:44
+#: connectors/installer.php:46 includes/updater.php:213
 msgid "Activated"
 msgstr ""
 
-#: connectors/installer.php:45 connectors/widgets.php:40
+#: connectors/installer.php:47 connectors/widgets.php:42
 msgid "Deactivated"
 msgstr ""
 
-#: connectors/installer.php:48 connectors/media.php:41 connectors/menus.php:38
-#: connectors/posts.php:36 connectors/settings.php:48
-#: connectors/taxonomies.php:65 connectors/users.php:52
-#: connectors/widgets.php:41
-msgid "Updated"
-msgstr ""
-
-#: connectors/installer.php:59
+#: connectors/installer.php:61
 msgid "Plugins"
 msgstr ""
 
-#: connectors/installer.php:60
+#: connectors/installer.php:62
 msgid "Themes"
 msgstr ""
 
-#: connectors/installer.php:61
+#: connectors/installer.php:63
 msgid "WordPress"
 msgstr ""
 
-#: connectors/installer.php:78
+#: connectors/installer.php:80
 msgid "About"
 msgstr ""
 
-#: connectors/installer.php:80
+#: connectors/installer.php:82
 msgid "View Release Notes"
 msgstr ""
 
-#: connectors/installer.php:110
+#: connectors/installer.php:135
 msgctxt ""
 "Plugin/theme installation. 1: Type (plugin/theme), 2: Plugin/theme name, 3: "
 "Plugin/theme version"
 msgid "Installed %1$s: %2$s %3$s"
 msgstr ""
 
-#: connectors/installer.php:142
+#: connectors/installer.php:143
 msgctxt ""
 "Plugin/theme update. 1: Type (plugin/theme), 2: Plugin/theme name, 3: Plugin/"
 "theme version"
 msgid "Updated %1$s: %2$s %3$s"
 msgstr ""
 
-#: connectors/installer.php:172 connectors/installer.php:188
-#: connectors/installer.php:246
+#: connectors/installer.php:205 connectors/installer.php:222
+#: connectors/installer.php:309
 msgid "network wide"
 msgstr ""
 
-#: connectors/installer.php:174
+#: connectors/installer.php:208
 msgctxt "1: Plugin name, 2: Single site or network wide"
 msgid "\"%1$s\" plugin activated %2$s"
 msgstr ""
 
-#: connectors/installer.php:190
+#: connectors/installer.php:225
 msgctxt "1: Plugin name, 2: Single site or network wide"
 msgid "\"%1$s\" plugin deactivated %2$s"
 msgstr ""
 
-#: connectors/installer.php:204
+#: connectors/installer.php:240
 msgid "\"%s\" theme activated"
 msgstr ""
 
-#: connectors/installer.php:219
+#: connectors/installer.php:269
 msgid "\"%s\" theme deleted"
 msgstr ""
 
-#: connectors/installer.php:248
+#: connectors/installer.php:312
 msgid "\"%s\" plugin deleted"
 msgstr ""
 
-#: connectors/installer.php:287
+#: connectors/installer.php:359
 msgctxt "Plugin/theme editing. 1: Type (plugin/theme), 2: Plugin/theme name"
 msgid "Edited %1$s: %2$s"
 msgstr ""
 
-#: connectors/installer.php:305
+#: connectors/installer.php:379
 msgid "WordPress auto-updated to %s"
 msgstr ""
 
-#: connectors/installer.php:307
+#: connectors/installer.php:381
 msgid "WordPress updated to %s"
 msgstr ""
 
-#: connectors/media.php:29 connectors/media.php:55 connectors/settings.php:64
+#: connectors/media.php:31 connectors/settings.php:120
 msgid "Media"
 msgstr ""
 
-#: connectors/media.php:39
+#: connectors/media.php:41
 msgid "Attached"
 msgstr ""
 
-#: connectors/media.php:40
+#: connectors/media.php:42
 msgid "Uploaded"
 msgstr ""
 
-#: connectors/media.php:43 connectors/menus.php:40
+#: connectors/media.php:45 connectors/menus.php:42
 msgid "Assigned"
 msgstr ""
 
-#: connectors/media.php:44 connectors/menus.php:41
+#: connectors/media.php:46 connectors/menus.php:43
 msgid "Unassigned"
 msgstr ""
 
-#: connectors/media.php:70
+#: connectors/media.php:59
+msgid "Image"
+msgstr ""
+
+#: connectors/media.php:60
+msgid "Audio"
+msgstr ""
+
+#: connectors/media.php:61
+msgid "Video"
+msgstr ""
+
+#: connectors/media.php:62
+msgid "Document"
+msgstr ""
+
+#: connectors/media.php:63
+msgid "Spreadsheet"
+msgstr ""
+
+#: connectors/media.php:64
+msgid "Interactive"
+msgstr ""
+
+#: connectors/media.php:65
+msgid "Text"
+msgstr ""
+
+#: connectors/media.php:66
+msgid "Archive"
+msgstr ""
+
+#: connectors/media.php:67
+msgid "Code"
+msgstr ""
+
+#: connectors/media.php:105
 msgid "Edit Media"
 msgstr ""
 
-#: connectors/media.php:73 connectors/posts.php:70
-#: connectors/taxonomies.php:94
+#: connectors/media.php:108 connectors/posts.php:101
+#: connectors/taxonomies.php:99
 msgid "View"
 msgstr ""
 
-#: connectors/media.php:87
+#: connectors/media.php:123
 msgctxt "1: Attachment title, 2: Parent post title"
 msgid "Attached \"%1$s\" to \"%2$s\""
 msgstr ""
 
-#: connectors/media.php:93
+#: connectors/media.php:129
 msgid "Added \"%s\" to Media library"
 msgstr ""
 
-#: connectors/media.php:115
+#: connectors/media.php:154
 msgid "Updated \"%s\""
 msgstr ""
 
-#: connectors/media.php:135
+#: connectors/media.php:175
 msgid "Deleted \"%s\""
 msgstr ""
 
-#: connectors/media.php:150
+#: connectors/media.php:198
 msgid "Edited image \"%s\""
 msgstr ""
 
-#: connectors/menus.php:27
+#: connectors/menus.php:29
 msgid "Menus"
 msgstr ""
 
-#: connectors/menus.php:80
+#: connectors/menus.php:84
 msgid "Edit Menu"
 msgstr ""
 
-#: connectors/menus.php:94
+#: connectors/menus.php:100
 msgid "Created new menu \"%s\""
 msgstr ""
 
-#: connectors/menus.php:112
+#: connectors/menus.php:120
 msgctxt "Menu name"
 msgid "Updated menu \"%s\""
 msgstr ""
 
-#: connectors/menus.php:128
+#: connectors/menus.php:137
 msgctxt "Menu name"
 msgid "Deleted \"%s\""
 msgstr ""
 
-#: connectors/menus.php:163
+#: connectors/menus.php:175
 msgctxt "1: Menu name, 2: Theme location"
 msgid "\"%1$s\" has been unassigned from \"%2$s\""
 msgstr ""
 
-#: connectors/menus.php:171
+#: connectors/menus.php:183
 msgctxt "1: Menu name, 2: Theme location"
 msgid "\"%1$s\" has been assigned to \"%2$s\""
 msgstr ""
 
-#: connectors/posts.php:26
+#: connectors/posts.php:28
 msgid "Posts"
 msgstr ""
 
-#: connectors/posts.php:67
+#: connectors/posts.php:95
+msgctxt "Post type singular name"
+msgid "Restore %s"
+msgstr ""
+
+#: connectors/posts.php:96
+msgctxt "Post type singular name"
+msgid "Delete %s Permenantly"
+msgstr ""
+
+#: connectors/posts.php:98
 msgctxt "Post type singular name"
 msgid "Edit %s"
 msgstr ""
 
-#: connectors/posts.php:74
+#: connectors/posts.php:105
 msgid "Revision"
-msgstr ""
-
-#: connectors/posts.php:96
-msgctxt "1: Post title, 2: Post type singular name"
-msgid "\"%1$s\" %2$s drafted"
-msgstr ""
-
-#: connectors/posts.php:104 connectors/posts.php:112
-msgctxt "1: Post title, 2: Post type singular name"
-msgid "\"%1$s\" %2$s published"
-msgstr ""
-
-#: connectors/posts.php:119
-msgctxt "1: Post title, 2: Post type singular name"
-msgid "\"%1$s\" %2$s unpublished"
 msgstr ""
 
 #: connectors/posts.php:126
 msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s drafted"
+msgstr ""
+
+#: connectors/posts.php:133 connectors/posts.php:140
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s published"
+msgstr ""
+
+#: connectors/posts.php:146
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s unpublished"
+msgstr ""
+
+#: connectors/posts.php:152
+msgctxt "1: Post title, 2: Post type singular name"
 msgid "\"%1$s\" %2$s trashed"
 msgstr ""
 
-#: connectors/posts.php:134
+#: connectors/posts.php:159
+msgctxt "1: Post title, 2: Post type singular name"
+msgid "\"%1$s\" %2$s restored from trash"
+msgstr ""
+
+#: connectors/posts.php:166
 msgctxt "1: Post title, 2: Post type singular name"
 msgid "\"%1$s\" %2$s updated"
 msgstr ""
 
-#: connectors/posts.php:196
+#: connectors/posts.php:232
 msgctxt "1: Post title, 2: Post type singular name"
 msgid "\"%1$s\" %2$s deleted from trash"
 msgstr ""
 
-#: connectors/settings.php:38 connectors/settings.php:59 includes/admin.php:99
-#: includes/admin.php:214
+#: connectors/posts.php:269
+msgid "Post"
+msgstr ""
+
+#: connectors/settings.php:94 connectors/settings.php:115
+#: includes/admin.php:129 includes/admin.php:316
 msgid "Settings"
 msgstr ""
 
-#: connectors/settings.php:60 includes/settings.php:56
+#: connectors/settings.php:116 includes/settings.php:241
 msgid "General"
 msgstr ""
 
-#: connectors/settings.php:61
+#: connectors/settings.php:117
 msgid "Writing"
 msgstr ""
 
-#: connectors/settings.php:62
+#: connectors/settings.php:118
 msgid "Reading"
 msgstr ""
 
-#: connectors/settings.php:63
+#: connectors/settings.php:119
 msgid "Discussion"
 msgstr ""
 
-#: connectors/settings.php:65
+#: connectors/settings.php:121
 msgid "Permalinks"
 msgstr ""
 
-#: connectors/settings.php:77
+#: connectors/settings.php:122
+msgid "Network"
+msgstr ""
+
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
+#. Plugin Name of the plugin/theme
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
+#. Author of the plugin/theme
+#: connectors/settings.php:123 includes/admin.php:117 includes/admin.php:118
+#: includes/network.php:72 includes/network.php:157
+msgid "Stream"
+msgstr ""
+
+#: connectors/settings.php:124
+msgid "Custom Background"
+msgstr ""
+
+#: connectors/settings.php:125
+msgid "Custom Header"
+msgstr ""
+
+#: connectors/settings.php:132
+msgid "Stream Network"
+msgstr ""
+
+#: connectors/settings.php:133
+msgid "Stream Defaults"
+msgstr ""
+
+#: connectors/settings.php:202
 msgid "Site Title"
 msgstr ""
 
-#: connectors/settings.php:78
+#: connectors/settings.php:203
 msgid "Tagline"
 msgstr ""
 
-#: connectors/settings.php:79
+#: connectors/settings.php:204
 msgid "WordPress Address (URL)"
 msgstr ""
 
-#: connectors/settings.php:80
+#: connectors/settings.php:205
 msgid "Site Address (URL)"
 msgstr ""
 
-#: connectors/settings.php:81
+#: connectors/settings.php:206
 msgid "E-mail Address"
 msgstr ""
 
-#: connectors/settings.php:82
+#: connectors/settings.php:207
 msgid "Membership"
 msgstr ""
 
-#: connectors/settings.php:83
+#: connectors/settings.php:208
 msgid "New User Default Role"
 msgstr ""
 
-#: connectors/settings.php:84
+#: connectors/settings.php:209
 msgid "Timezone"
 msgstr ""
 
-#: connectors/settings.php:85
+#: connectors/settings.php:210
 msgid "Date Format"
 msgstr ""
 
-#: connectors/settings.php:86
+#: connectors/settings.php:211
 msgid "Time Format"
 msgstr ""
 
-#: connectors/settings.php:87
+#: connectors/settings.php:212
 msgid "Week Starts On"
 msgstr ""
 
-#: connectors/settings.php:89 connectors/settings.php:90
+#: connectors/settings.php:214 connectors/settings.php:215
 msgid "Formatting"
 msgstr ""
 
-#: connectors/settings.php:91
+#: connectors/settings.php:216
 msgid "Default Post Category"
 msgstr ""
 
-#: connectors/settings.php:92
+#: connectors/settings.php:217
 msgid "Default Post Format"
 msgstr ""
 
-#: connectors/settings.php:93
-msgid "Mail Server Address"
+#: connectors/settings.php:218
+msgid "Mail Server"
 msgstr ""
 
-#: connectors/settings.php:94
-msgid "Mail Server Login Name"
+#: connectors/settings.php:219
+msgid "Login Name"
 msgstr ""
 
-#: connectors/settings.php:95
-msgid "Mail Server Password"
+#: connectors/settings.php:220
+msgid "Password"
 msgstr ""
 
-#: connectors/settings.php:96
+#: connectors/settings.php:221
 msgid "Default Mail Category"
 msgstr ""
 
-#: connectors/settings.php:97
+#: connectors/settings.php:222
 msgid "Update Services"
 msgstr ""
 
-#: connectors/settings.php:99 connectors/settings.php:100
-#: connectors/settings.php:101
+#: connectors/settings.php:224 connectors/settings.php:225
+#: connectors/settings.php:226
 msgid "Front page displays"
 msgstr ""
 
-#: connectors/settings.php:102
+#: connectors/settings.php:227
 msgid "Blog pages show at most"
 msgstr ""
 
-#: connectors/settings.php:103
+#: connectors/settings.php:228
 msgid "Syndication feeds show the most recent"
 msgstr ""
 
-#: connectors/settings.php:104
+#: connectors/settings.php:229
 msgid "For each article in a feed, show"
 msgstr ""
 
-#: connectors/settings.php:105
+#: connectors/settings.php:230
 msgid "Search Engine Visibility"
 msgstr ""
 
-#: connectors/settings.php:107 connectors/settings.php:108
-#: connectors/settings.php:109
+#: connectors/settings.php:232 connectors/settings.php:233
+#: connectors/settings.php:234
 msgid "Default article settings"
 msgstr ""
 
-#: connectors/settings.php:110 connectors/settings.php:111
-#: connectors/settings.php:112 connectors/settings.php:113
-#: connectors/settings.php:114 connectors/settings.php:115
-#: connectors/settings.php:116 connectors/settings.php:117
-#: connectors/settings.php:118 connectors/settings.php:119
+#: connectors/settings.php:235 connectors/settings.php:236
+#: connectors/settings.php:237 connectors/settings.php:238
+#: connectors/settings.php:239 connectors/settings.php:240
+#: connectors/settings.php:241 connectors/settings.php:242
+#: connectors/settings.php:243 connectors/settings.php:244
 msgid "Other comment settings"
 msgstr ""
 
-#: connectors/settings.php:120 connectors/settings.php:121
+#: connectors/settings.php:245 connectors/settings.php:246
 msgid "E-mail me whenever"
 msgstr ""
 
-#: connectors/settings.php:122 connectors/settings.php:123
+#: connectors/settings.php:247 connectors/settings.php:248
 msgid "Before a comment appears"
 msgstr ""
 
-#: connectors/settings.php:124 connectors/settings.php:125
+#: connectors/settings.php:249 connectors/settings.php:250
 msgid "Comment Moderation"
 msgstr ""
 
-#: connectors/settings.php:126
+#: connectors/settings.php:251
 msgid "Comment Blacklist"
 msgstr ""
 
-#: connectors/settings.php:127
-msgid "Avatar Display"
+#: connectors/settings.php:252
+msgid "Show Avatars"
 msgstr ""
 
-#: connectors/settings.php:128
-msgid "Avatar Maximum Rating"
+#: connectors/settings.php:253
+msgid "Maximum Rating"
 msgstr ""
 
-#: connectors/settings.php:129
+#: connectors/settings.php:254
 msgid "Default Avatar"
 msgstr ""
 
-#: connectors/settings.php:131 connectors/settings.php:132
-#: connectors/settings.php:133
-msgid "Thumbnail Image Size"
+#: connectors/settings.php:256 connectors/settings.php:257
+#: connectors/settings.php:258
+msgid "Thumbnail size"
 msgstr ""
 
-#: connectors/settings.php:134 connectors/settings.php:135
-msgid "Medium Image Size"
+#: connectors/settings.php:259 connectors/settings.php:260
+msgid "Medium size"
 msgstr ""
 
-#: connectors/settings.php:136 connectors/settings.php:137
-msgid "Large Image Size"
+#: connectors/settings.php:261 connectors/settings.php:262
+msgid "Large size"
 msgstr ""
 
-#: connectors/settings.php:138
-msgid "Uploading Files Organization"
+#: connectors/settings.php:263
+msgid "Uploading Files"
 msgstr ""
 
-#: connectors/settings.php:140
-msgid "Permalink structure"
+#: connectors/settings.php:265
+msgid "Permalink Settings"
 msgstr ""
 
-#: connectors/settings.php:141
+#: connectors/settings.php:266
 msgid "Category base"
 msgstr ""
 
-#: connectors/settings.php:142
+#: connectors/settings.php:267
 msgid "Tag base"
 msgstr ""
 
-#: connectors/settings.php:174
+#: connectors/settings.php:269
+msgid "Registration notification"
+msgstr ""
+
+#: connectors/settings.php:270
+msgid "Allow new registrations"
+msgstr ""
+
+#: connectors/settings.php:271
+msgid "Add New Users"
+msgstr ""
+
+#: connectors/settings.php:272
+msgid "Enable administration menus"
+msgstr ""
+
+#: connectors/settings.php:273
+msgid "Site upload space check"
+msgstr ""
+
+#: connectors/settings.php:274
+msgid "Site upload space"
+msgstr ""
+
+#: connectors/settings.php:275
+msgid "Upload file types"
+msgstr ""
+
+#: connectors/settings.php:276
+msgid "Network Title"
+msgstr ""
+
+#: connectors/settings.php:277
+msgid "First Post"
+msgstr ""
+
+#: connectors/settings.php:278
+msgid "First Page"
+msgstr ""
+
+#: connectors/settings.php:279
+msgid "First Comment"
+msgstr ""
+
+#: connectors/settings.php:280
+msgid "First Comment URL"
+msgstr ""
+
+#: connectors/settings.php:281
+msgid "First Comment Author"
+msgstr ""
+
+#: connectors/settings.php:282
+msgid "Welcome Email"
+msgstr ""
+
+#: connectors/settings.php:283
+msgid "Welcome User Email"
+msgstr ""
+
+#: connectors/settings.php:284
+msgid "Max upload file size"
+msgstr ""
+
+#: connectors/settings.php:285
+msgid "Terms Enabled"
+msgstr ""
+
+#: connectors/settings.php:286
+msgid "Banned Names"
+msgstr ""
+
+#: connectors/settings.php:287
+msgid "Limited Email Registrations"
+msgstr ""
+
+#: connectors/settings.php:288
+msgid "Banned Email Domains"
+msgstr ""
+
+#: connectors/settings.php:289
+msgid "Network Language"
+msgstr ""
+
+#: connectors/settings.php:290
+msgid "Network Admin Email"
+msgstr ""
+
+#: connectors/settings.php:292
+msgid "Stream Database Version"
+msgstr ""
+
+#: connectors/settings.php:321
+msgid "Background Image"
+msgstr ""
+
+#: connectors/settings.php:322
+msgid "Background Position"
+msgstr ""
+
+#: connectors/settings.php:323
+msgid "Background Repeat"
+msgstr ""
+
+#: connectors/settings.php:324
+msgid "Background Attachment"
+msgstr ""
+
+#: connectors/settings.php:325
+msgid "Background Color"
+msgstr ""
+
+#: connectors/settings.php:327
+msgid "Header Image"
+msgstr ""
+
+#: connectors/settings.php:328
+msgid "Text Color"
+msgstr ""
+
+#: connectors/settings.php:461
 msgid "Edit %s Settings"
 msgstr ""
 
-#: connectors/settings.php:255
+#: connectors/settings.php:595
 msgid "\"%s\" setting was updated"
 msgstr ""
 
-#: connectors/taxonomies.php:54
+#: connectors/taxonomies.php:53
 msgid "Taxonomies"
 msgstr ""
 
-#: connectors/taxonomies.php:113
+#: connectors/taxonomies.php:98
+msgctxt "Term singular name"
+msgid "Edit %s"
+msgstr ""
+
+#: connectors/taxonomies.php:124
 msgctxt "1: Term name, 2: Taxonomy singular label"
 msgid "\"%1$s\" %2$s created"
 msgstr ""
 
-#: connectors/taxonomies.php:137
+#: connectors/taxonomies.php:152
 msgctxt "1: Term name, 2: Taxonomy singular label"
 msgid "\"%1$s\" %2$s deleted"
 msgstr ""
 
-#: connectors/taxonomies.php:169
+#: connectors/taxonomies.php:190
 msgctxt "1: Term name, 2: Taxonomy singular label"
 msgid "\"%1$s\" %2$s updated"
 msgstr ""
 
-#: connectors/users.php:42 connectors/users.php:70
+#: connectors/users.php:43 connectors/users.php:70
 msgid "Users"
 msgstr ""
 
-#: connectors/users.php:55
+#: connectors/users.php:56
 msgid "Password Reset"
 msgstr ""
 
-#: connectors/users.php:56
-msgid "Forgot Password"
-msgstr ""
-
 #: connectors/users.php:57
-msgid "Login"
+msgid "Lost Password"
 msgstr ""
 
 #: connectors/users.php:58
-msgid "Logout"
+msgid "Log In"
 msgstr ""
 
 #: connectors/users.php:59
-msgid "Failed Login"
+msgid "Log Out"
 msgstr ""
 
-#: connectors/users.php:85
-msgid "Edit Profile"
+#: connectors/users.php:71
+msgid "Sessions"
 msgstr ""
 
-#: connectors/users.php:131
-msgid "New user registration"
+#: connectors/users.php:72
+msgid "Profiles"
+msgstr ""
+
+#: connectors/users.php:87
+msgid "Edit User"
 msgstr ""
 
 #: connectors/users.php:134
+msgid "New user registration"
+msgstr ""
+
+#: connectors/users.php:137
 msgctxt "1: User display name, 2: User role"
 msgid "New user account created for %1$s (%2$s)"
 msgstr ""
 
-#: connectors/users.php:163
+#: connectors/users.php:164
 msgid "%s's profile was updated"
 msgstr ""
 
@@ -647,339 +959,753 @@ msgctxt "1: User display name, 2: Old role, 3: New role"
 msgid "%1$s's role was changed from %2$s to %3$s"
 msgstr ""
 
-#: connectors/users.php:210
+#: connectors/users.php:208
 msgid "%s's password was reset"
 msgstr ""
 
-#: connectors/users.php:234
+#: connectors/users.php:231
 msgid "%s's password was requested to be reset"
 msgstr ""
 
-#: connectors/users.php:254
+#: connectors/users.php:249
 msgid "%s logged in"
 msgstr ""
 
-#: connectors/users.php:279
+#: connectors/users.php:272
 msgid "%s logged out"
 msgstr ""
 
-#: connectors/users.php:317
+#: connectors/users.php:306
 msgctxt "1: User display name, 2: User roles"
 msgid "%1$s's account was deleted (%2$s)"
 msgstr ""
 
-#: connectors/users.php:326
+#: connectors/users.php:315
 msgid "User account #%d was deleted"
 msgstr ""
 
-#: connectors/users.php:354
-msgid "Invalid login attempt for %s"
-msgstr ""
-
-#: connectors/widgets.php:28 connectors/widgets.php:53
+#: connectors/widgets.php:30 connectors/widgets.php:269
+#: connectors/widgets.php:316
 msgid "Widgets"
 msgstr ""
 
-#: connectors/widgets.php:38
+#: connectors/widgets.php:40
 msgid "Added"
 msgstr ""
 
-#: connectors/widgets.php:42
+#: connectors/widgets.php:44
 msgid "Sorted"
 msgstr ""
 
-#: connectors/widgets.php:69
+#: connectors/widgets.php:62
+msgid "Inactive Widgets"
+msgstr ""
+
+#: connectors/widgets.php:80
 msgid "Edit Widget Area"
 msgstr ""
 
-#: connectors/widgets.php:95
-msgctxt "1: Widget title, 2: Sidebar name"
-msgid "\"%1$s\" from \"%2$s\" has been deactivated"
+#: connectors/widgets.php:109
+msgctxt "1: Widget title"
+msgid "\"%1$s\" has been deactivated"
 msgstr ""
 
-#: connectors/widgets.php:135
+#: connectors/widgets.php:153
 msgctxt "1: Widget title, 2: Sidebar name"
 msgid "\"%1$s\" has been added to \"%2$s\""
 msgstr ""
 
-#: connectors/widgets.php:146
+#: connectors/widgets.php:164
 msgctxt "1: Widget title, 2: Sidebar name"
 msgid "\"%1$s\" has been deleted from \"%2$s\""
 msgstr ""
 
-#: connectors/widgets.php:199
+#: connectors/widgets.php:221
 msgctxt "1: Widget title, 2: Sidebar name"
-msgid "Updated \"%1$s\" in \"%2$s\""
+msgid "\"%1$s\" in \"%2$s\" updated"
 msgstr ""
 
-#: connectors/widgets.php:250
+#: connectors/widgets.php:275
 msgctxt "Sidebar name"
-msgid "\"%s\" widgets were reordered"
+msgid "Widgets in \"%s\" were reordered"
 msgstr ""
 
-#: includes/admin.php:74
+#: includes/admin.php:93
 msgid "All records have been successfully erased."
 msgstr ""
 
-#. #-#-#-#-#  stream.pot (Stream 1.0.3)  #-#-#-#-#
-#. Plugin Name of the plugin/theme
-#: includes/admin.php:87 includes/admin.php:88
-msgid "Stream"
+#: includes/admin.php:96
+msgid "All site settings have been successfully reset."
 msgstr ""
 
-#: includes/admin.php:98 includes/admin.php:238
+#: includes/admin.php:128
 msgid "Stream Settings"
 msgstr ""
 
-#: includes/admin.php:136
+#: includes/admin.php:138 includes/extensions.php:159
+#: includes/extensions.php:226 includes/extensions.php:260
+#: includes/network.php:148 includes/network.php:156 includes/pointers.php:144
+msgid "Stream Extensions"
+msgstr ""
+
+#: includes/admin.php:139 includes/network.php:149
+msgid "Extensions"
+msgstr ""
+
+#: includes/admin.php:196
 msgid ""
 "Are you sure you want to delete all Stream activity records from the "
 "database? This cannot be undone."
 msgstr ""
 
-#: includes/admin.php:137
+#: includes/admin.php:197
+msgid ""
+"Are you sure you want to reset all site settings to default? This cannot be "
+"undone."
+msgstr ""
+
+#: includes/admin.php:198
 msgid ""
 "Are you sure you want to uninstall and deactivate Stream? This will delete "
 "all Stream tables from the database and cannot be undone."
 msgstr ""
 
-#: includes/admin.php:223
+#: includes/admin.php:325
 msgid "Uninstall"
 msgstr ""
 
-#: includes/admin.php:287
+#: includes/admin.php:478
+msgid "Connected"
+msgstr ""
+
+#: includes/admin.php:479 includes/extensions.php:229
+msgid "Connect to Stream Extensions"
+msgstr ""
+
+#: includes/admin.php:501
+msgid "Return to Stream Extensions"
+msgstr ""
+
+#: includes/admin.php:514 includes/admin.php:520 includes/admin.php:522
 msgid "Stream Records"
 msgstr ""
 
-#: includes/admin.php:450
+#: includes/admin.php:519
+msgid "1 site"
+msgid_plural "%d sites"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin.php:823
+msgid "One more result..."
+msgid_plural "%d more results..."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/class-wp-stream-author.php:61
+#: includes/class-wp-stream-author.php:69
+msgid "N/A"
+msgstr ""
+
+#: includes/class-wp-stream-author.php:234
+msgid "via WP-CLI"
+msgstr ""
+
+#: includes/class-wp-stream-author.php:236
+msgid "during WP Cron"
+msgstr ""
+
+#: includes/connectors.php:90
+msgid "%s class wasn't loaded because it doesn't extends the %s class."
+msgstr ""
+
+#: includes/dashboard.php:25
+msgid "Network Stream Activity"
+msgstr ""
+
+#: includes/dashboard.php:25
 msgid "Stream Activity"
 msgstr ""
 
-#: includes/admin.php:469
+#: includes/dashboard.php:57
 msgid "Sorry, no activity records were found."
 msgstr ""
 
-#: includes/admin.php:495
+#: includes/dashboard.php:106
+msgid "View all records"
+msgstr ""
+
+#: includes/dashboard.php:108
+msgid "View All"
+msgstr ""
+
+#: includes/dashboard.php:126
+msgid "Go to the first page"
+msgstr ""
+
+#: includes/dashboard.php:134
+msgid "Go to the previous page"
+msgstr ""
+
+#: includes/dashboard.php:141
+msgctxt "paging"
+msgid "%1$s of %2$s"
+msgstr ""
+
+#: includes/dashboard.php:146
+msgid "Go to the next page"
+msgstr ""
+
+#: includes/dashboard.php:155
+msgid "Go to the last page"
+msgstr ""
+
+#: includes/dashboard.php:192 includes/list-table.php:22
+msgid "Records per page"
+msgstr ""
+
+#: includes/dashboard.php:197
+msgid "Enable live updates"
+msgstr ""
+
+#: includes/dashboard.php:217
 msgctxt "1: Time, 2: User profile URL, 3: User display name"
 msgid "%1$s ago by <a href=\"%2$s\">%3$s</a>"
 msgstr ""
 
-#: includes/admin.php:506 includes/list-table.php:134
-msgid "%s ago"
+#: includes/date-interval.php:51
+msgid "Today"
 msgstr ""
 
-#: includes/admin.php:531
-msgid "View all Stream Records"
+#: includes/date-interval.php:56
+msgid "Yesterday"
 msgstr ""
 
-#: includes/admin.php:532
-msgid "More"
+#: includes/date-interval.php:61 includes/date-interval.php:66
+#: includes/date-interval.php:71
+msgid "Last %d Days"
 msgstr ""
 
-#: includes/admin.php:554
-msgid "Number of Records"
+#: includes/date-interval.php:76
+msgid "This Month"
 msgstr ""
 
-#: includes/feeds.php:73
+#: includes/date-interval.php:80
+msgid "Last Month"
+msgstr ""
+
+#: includes/date-interval.php:85 includes/date-interval.php:90
+#: includes/date-interval.php:95
+msgid "Last %d Months"
+msgstr ""
+
+#: includes/date-interval.php:100
+msgid "This Year"
+msgstr ""
+
+#: includes/date-interval.php:104
+msgid "Last Year"
+msgstr ""
+
+#: includes/db-updates.php:110 includes/db-updates.php:204
+#: includes/db-updates.php:226 includes/db-updates.php:490
+#: includes/db-updates.php:518 includes/db-updates.php:555
+msgid "Database Update Error"
+msgstr ""
+
+#: includes/deprecated.php:55
+msgid "The %s filter"
+msgstr ""
+
+#: includes/extensions.php:159
+msgid "You must connect to your %s account to install extensions."
+msgstr ""
+
+#: includes/extensions.php:159
+msgid "Don't have an account?"
+msgstr ""
+
+#: includes/extensions.php:159 includes/extensions.php:239
+msgid "Join Stream Extensions"
+msgstr ""
+
+#: includes/extensions.php:231
+msgid "Disconnect"
+msgstr ""
+
+#: includes/extensions.php:238
+msgid ""
+"Connect your Stream Extensions account and authorize this domain to install "
+"and receive automatic updates for premium extensions. Don't have an account?"
+msgstr ""
+
+#: includes/extensions.php:243
+msgid "Your account is connected!"
+msgstr ""
+
+#: includes/extensions.php:262
+msgid "Sorry, there was a problem loading the list of extensions."
+msgstr ""
+
+#: includes/extensions.php:264
+msgid "Browse All Extensions"
+msgstr ""
+
+#: includes/extensions.php:306
+msgid "View Details"
+msgstr ""
+
+#: includes/extensions.php:310
+msgid "Inactive"
+msgstr ""
+
+#: includes/extensions.php:318
+msgid "Get This Extension"
+msgstr ""
+
+#: includes/extensions.php:322 includes/extensions.php:375
+msgid "Install Now"
+msgstr ""
+
+#: includes/extensions.php:327 includes/extensions.php:376
+#: includes/updater.php:210
+msgid "Activate"
+msgstr ""
+
+#: includes/extensions.php:330 includes/extensions.php:377
+msgid "Active"
+msgstr ""
+
+#: includes/feeds.php:125
 msgid "Stream Feeds Key"
 msgstr ""
 
-#: includes/feeds.php:77
+#: includes/feeds.php:130
 msgid "Generate new key"
 msgstr ""
 
-#: includes/feeds.php:79
+#: includes/feeds.php:133
 msgid ""
 "This is your private key used for accessing feeds of Stream Records "
 "securely. You can change your key at any time by generating a new one using "
 "the link above."
 msgstr ""
 
-#: includes/feeds.php:81
+#: includes/feeds.php:135
 msgid "RSS Feed"
 msgstr ""
 
-#: includes/feeds.php:83
+#: includes/feeds.php:137
 msgid "JSON Feed"
 msgstr ""
 
-#: includes/feeds.php:97
+#: includes/feeds.php:185
 msgid "Access Denied"
 msgstr ""
 
-#: includes/feeds.php:98
+#: includes/feeds.php:186
 msgid ""
 "You don't have permission to view this feed, please contact your site "
 "Administrator."
 msgstr ""
 
-#: includes/feeds.php:160
+#: includes/feeds.php:270
 msgid "Stream Feed"
 msgstr ""
 
-#: includes/list-table.php:18
-msgid "Records per page"
+#: includes/filter-input.php:49
+msgid "Invalid use, type must be one of INPUT_* family."
 msgstr ""
 
-#: includes/list-table.php:38
+#: includes/filter-input.php:65
+msgid "Filter not supported."
+msgstr ""
+
+#: includes/install.php:172
+msgid "There was an error updating the Stream database. Please try again."
+msgstr ""
+
+#: includes/install.php:206
+msgid "Stream Database Update Required"
+msgstr ""
+
+#: includes/install.php:207
+msgid ""
+"Stream has updated! Before we send you on your way, we need to update your "
+"database to the newest version."
+msgstr ""
+
+#: includes/install.php:208
+msgid "This process could take a little while, so please be patient."
+msgstr ""
+
+#: includes/install.php:209
+msgid "Update Database"
+msgstr ""
+
+#: includes/install.php:227
+msgid "Update Complete"
+msgstr ""
+
+#: includes/install.php:229
+msgid "Continue"
+msgstr ""
+
+#: includes/list-table.php:53
 msgid "Date"
 msgstr ""
 
-#: includes/list-table.php:39
+#: includes/list-table.php:54
 msgid "Summary"
 msgstr ""
 
-#: includes/list-table.php:40
+#: includes/list-table.php:55
 msgid "Author"
 msgstr ""
 
-#: includes/list-table.php:41
+#: includes/list-table.php:56
 msgid "Connector"
 msgstr ""
 
-#: includes/list-table.php:42
+#: includes/list-table.php:57
 msgid "Context"
 msgstr ""
 
-#: includes/list-table.php:43
+#: includes/list-table.php:58
 msgid "Action"
 msgstr ""
 
-#: includes/list-table.php:44
+#: includes/list-table.php:59
 msgid "IP Address"
 msgstr ""
 
-#: includes/list-table.php:45
-msgid "ID"
+#: includes/list-table.php:60
+msgid "Record ID"
 msgstr ""
 
-#: includes/list-table.php:150
+#: includes/list-table.php:201
 msgid "View all records for this object"
 msgstr ""
 
-#: includes/list-table.php:173
-msgid "N/A"
+#: includes/list-table.php:218
+msgid "Deleted User"
 msgstr ""
 
-#: includes/list-table.php:301
+#: includes/list-table.php:484
+msgid "dates"
+msgstr ""
+
+#: includes/list-table.php:493
 msgid "authors"
 msgstr ""
 
-#: includes/list-table.php:309
+#: includes/list-table.php:499
 msgid "connectors"
 msgstr ""
 
-#: includes/list-table.php:317
+#: includes/list-table.php:504
 msgid "contexts"
 msgstr ""
 
-#: includes/list-table.php:325
+#: includes/list-table.php:509
 msgid "actions"
 msgstr ""
 
-#: includes/list-table.php:337
+#: includes/list-table.php:531
+msgid "Show filter controls via the screen options tab above."
+msgstr ""
+
+#: includes/list-table.php:541
 msgid "Filter"
 msgstr ""
 
-#: includes/list-table.php:356
+#: includes/list-table.php:573
 msgid "Show all %s"
 msgstr ""
 
-#: includes/list-table.php:369
+#: includes/list-table.php:588
 msgid "Search Records"
 msgstr ""
 
-#: includes/list-table.php:389
-msgid "Date start"
+#: includes/list-table.php:608
+msgid "All Time"
 msgstr ""
 
-#: includes/list-table.php:391
-msgid "Date end"
+#: includes/list-table.php:610
+msgid "Custom"
 msgstr ""
 
-#: includes/list-table.php:455
+#: includes/list-table.php:629
+msgid "Start Date"
+msgstr ""
+
+#: includes/list-table.php:639
+msgid "End Date"
+msgstr ""
+
+#: includes/list-table.php:713
 msgid "Live updates"
 msgstr ""
 
-#: includes/list-table.php:461 includes/settings.php:83
+#: includes/list-table.php:724 includes/network.php:291
+#: includes/settings.php:270
 msgid "Enabled"
 msgstr ""
 
-#: includes/settings.php:60
-msgid "Log Activity for"
+#: includes/live-update.php:115
+msgid "1 item"
+msgid_plural "%s items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/network.php:85
+msgid "Network Admin"
 msgstr ""
 
-#: includes/settings.php:62
-msgid "Only the selected roles above will have their activity logged."
+#: includes/network.php:128
+msgid "Stream Network Settings"
 msgstr ""
 
-#: includes/settings.php:68
+#: includes/network.php:129
+msgid "Network Settings"
+msgstr ""
+
+#: includes/network.php:138
+msgid "New Site Settings"
+msgstr ""
+
+#: includes/network.php:139
+msgid "Site Defaults"
+msgstr ""
+
+#: includes/network.php:213
+msgid "These settings apply to all sites on the network."
+msgstr ""
+
+#: includes/network.php:216
+msgid ""
+"These default settings will apply to new sites created on the network. These "
+"settings do not alter existing sites."
+msgstr ""
+
+#: includes/network.php:290
+msgid "Enable Site Access"
+msgstr ""
+
+#: includes/network.php:293
+msgid ""
+"When site access is disabled Stream can only be accessed from the network "
+"administration."
+msgstr ""
+
+#: includes/network.php:309
+msgid "Reset Site Settings"
+msgstr ""
+
+#: includes/network.php:312
+msgid "Warning: Clicking this will override all site settings with defaults."
+msgstr ""
+
+#: includes/network.php:396
+msgid "Settings saved."
+msgstr ""
+
+#: includes/network.php:454
+msgid "sites"
+msgstr ""
+
+#: includes/network.php:471 includes/network.php:521
+msgid "Site"
+msgstr ""
+
+#: includes/pointers.php:145
+msgid "Extension plugins are now available for Stream!"
+msgstr ""
+
+#: includes/settings.php:88
+msgid "There was an error in the request"
+msgstr ""
+
+#: includes/settings.php:134
+msgid ""
+"ID: %d\n"
+"User: %s\n"
+"Email: %s\n"
+"Role: %s"
+msgstr ""
+
+#: includes/settings.php:153
+msgid ""
+"Actions performed by the system when a user is not logged in (e.g. auto site "
+"upgrader, or invoking WP-CLI without --user)"
+msgstr ""
+
+#: includes/settings.php:245
 msgid "Role Access"
 msgstr ""
 
-#: includes/settings.php:70
+#: includes/settings.php:247
 msgid ""
 "Users from the selected roles above will have permission to view Stream "
 "Records. However, only site Administrators can access Stream Settings."
 msgstr ""
 
-#: includes/settings.php:76
+#: includes/settings.php:253
 msgid "Private Feeds"
 msgstr ""
 
-#: includes/settings.php:79
+#: includes/settings.php:256
 msgid ""
 "Users from the selected roles above will be given a private key found in "
-"their <a href=\"%s\" title=\"%s\">user profile</a> to access feeds of Stream "
-"Records securely."
+"their %suser profile%s to access feeds of Stream Records securely. Please "
+"%sflush rewrite rules%s on your site after changing this setting."
 msgstr ""
 
-#: includes/settings.php:81
+#: includes/settings.php:260
 msgid "View Profile"
 msgstr ""
 
-#: includes/settings.php:88
+#: includes/settings.php:266
+msgid "View Codex"
+msgstr ""
+
+#: includes/settings.php:275
 msgid "Keep Records for"
 msgstr ""
 
-#: includes/settings.php:91
+#: includes/settings.php:278
 msgid ""
 "Maximum number of days to keep activity records. Leave blank to keep records "
 "forever."
 msgstr ""
 
-#: includes/settings.php:93
+#: includes/settings.php:280
 msgid "days"
 msgstr ""
 
-#: includes/settings.php:97
-msgid "Delete All Records"
+#: includes/settings.php:284
+msgid "Reset Stream Database"
 msgstr ""
 
-#: includes/settings.php:106
+#: includes/settings.php:293
 msgid ""
 "Warning: Clicking this will delete all activity records from the database."
 msgstr ""
 
-#: includes/settings.php:278
-msgid "Reset Stream Database"
+#: includes/settings.php:299
+msgid "Exclude"
 msgstr ""
 
-#: stream.php:166
-msgid "The following table is not present in the WordPress database :"
+#: includes/settings.php:303
+msgid "Authors &amp; Roles"
 msgstr ""
 
-#: stream.php:174
+#: includes/settings.php:305
+msgid "No activity will be logged for these authors and/or roles."
+msgstr ""
+
+#: includes/settings.php:311
+msgid "Connectors"
+msgstr ""
+
+#: includes/settings.php:313
+msgid "No activity will be logged for these connectors."
+msgstr ""
+
+#: includes/settings.php:320
+msgid "Contexts"
+msgstr ""
+
+#: includes/settings.php:322
+msgid "No activity will be logged for these contexts."
+msgstr ""
+
+#: includes/settings.php:329
+msgid "Actions"
+msgstr ""
+
+#: includes/settings.php:331
+msgid "No activity will be logged for these actions."
+msgstr ""
+
+#: includes/settings.php:338
+msgid "IP Addresses"
+msgstr ""
+
+#: includes/settings.php:340
+msgid "No activity will be logged for these IP addresses."
+msgstr ""
+
+#: includes/settings.php:347
+msgid "Visibility"
+msgstr ""
+
+#: includes/settings.php:350
+msgid ""
+"When checked, all past records that match the excluded rules above will be "
+"hidden from view."
+msgstr ""
+
+#: includes/settings.php:352
+msgid "Hide Previous Records"
+msgstr ""
+
+#: includes/settings.php:709
+msgid "1 user"
+msgid_plural "%s users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/updater.php:65 includes/updater.php:130
+msgid "Could not connect to Stream update center."
+msgstr ""
+
+#: includes/updater.php:151 includes/updater.php:186
+msgid "Invalid security check."
+msgstr ""
+
+#: includes/updater.php:166
+msgid "Could not connect to Stream license server to verify license details."
+msgstr ""
+
+#: includes/updater.php:196
+msgid "Site disconnected successfully from your Stream account."
+msgstr ""
+
+#: includes/updater.php:231
+msgid ""
+"You must subscribe to Stream &copy; to be able to download premium "
+"extensions."
+msgstr ""
+
+#: includes/updater.php:262
+msgid "Installing %s Stream extension."
+msgstr ""
+
+#: includes/updater.php:277
+msgid "Extension was downloaded and activated successfully!"
+msgstr ""
+
+#: stream.php:149
+msgid "Stream requires PHP version 5.3+, plugin is currently NOT ACTIVE."
+msgstr ""
+
+#: stream.php:211
+msgid "The following table is not present in the WordPress database:"
+msgid_plural "The following tables are not present in the WordPress database:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: stream.php:222 stream.php:224
 msgid ""
 "Please <a href=\"%s\">uninstall</a> the Stream plugin and activate it again."
 msgstr ""
 
-#: stream.php:188
-msgid "Stream requires PHP version 5.3+, plugin is currently NOT ACTIVE."
-msgstr ""
-
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
 #. Plugin URI of the plugin/theme
-msgid "http://wordpress.org/plugins/stream/"
+#. #-#-#-#-#  stream.pot (Stream 1.4.6)  #-#-#-#-#
+#. Author URI of the plugin/theme
+msgid "https://wp-stream.com/"
 msgstr ""
 
 #. Description of the plugin/theme
@@ -988,12 +1714,4 @@ msgid ""
 "on your WordPress site in beautifully organized detail. All activity is "
 "organized by context, action and IP address for easy filtering. Developers "
 "can extend Stream with custom connectors to log any kind of action."
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "X-Team"
-msgstr ""
-
-#. Author URI of the plugin/theme
-msgid "http://x-team.com/wordpress/"
 msgstr ""


### PR DESCRIPTION
I was going to translate some strings but first I saw that a new `stream.pot` and `stream.po` files were required because the current one is from version `1.0.3`.

On x-team/wp-stream#204 you guys said that there was going to be some usage on http://wp-translate.org/projects, I submitted some strings (pt_BR) there about 3 months ago and since then no updates.

I was thinking on using Transifex which is working very well for MailPoet and now for FakerPress (my own project).

cc: @fjarrett @shadyvb @lukecarbis
