### PR TITLE
Transient cache verify_database_present for 24 hrs

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -224,7 +224,7 @@ class WP_Stream {
 				);
 			}
 
-			if ( is_plugin_active_for_network( WP_STREAM_PLUGIN ) && current_user_can( 'manage_network_plugins' ) ) {
+			if ( is_a( $this->network, 'WP_Stream_Network' ) && $this->network->is_network_activated() && current_user_can( 'manage_network_plugins' ) ) {
 				$uninstall_message = sprintf( __( 'Please <a href="%s">uninstall</a> the Stream plugin and activate it again.', 'stream' ), network_admin_url( 'plugins.php#stream' ) );
 			} elseif ( current_user_can( 'activate_plugins' ) ) {
 				$uninstall_message = sprintf( __( 'Please <a href="%s">uninstall</a> the Stream plugin and activate it again.', 'stream' ), admin_url( 'plugins.php#stream' ) );


### PR DESCRIPTION
Hi, 

I hope you find this useful; this change eliminates the repeated db queries to verify the database tables present, by storing the results in a transient cache.
- cache both $database_message and  $uninstall_message and reuse if possible, assuming database availability unlikely to change
