### PR TITLE
Widgets connector selected automatically

### DIFF
--- a/connectors/class-wp-stream-connector-widgets.php
+++ b/connectors/class-wp-stream-connector-widgets.php
@@ -80,7 +80,6 @@ class WP_Stream_Connector_Widgets extends WP_Stream_Connector {
 
 		$labels['wp_inactive_widgets'] = __( 'Inactive Widgets', 'default' );
 		$labels['orphaned_widgets']    = __( 'Orphaned Widgets', 'stream' );
-		$labels['']                    = __( 'Unknown', 'stream' );
 
 		return $labels;
 	}


### PR DESCRIPTION
Closes #613.

This issue was caused by one of the labels for the Widget connector having an empty string as the key. This of course matched when the `$_GET` param was empty.

I considered adding additional checks for empty connector label keys, but it became cumbersome and confusing.

@fjarrett Please review.
