### PR TITLE
Use singular name in taxonomy context labels

### DIFF
--- a/connectors/class-wp-stream-connector-taxonomies.php
+++ b/connectors/class-wp-stream-connector-taxonomies.php
@@ -67,7 +67,7 @@ class WP_Stream_Connector_Taxonomies extends WP_Stream_Connector {
 
 		$labels = wp_list_pluck( $wp_taxonomies, 'labels' );
 
-		self::$context_labels  = wp_list_pluck( $labels, 'name' );
+		self::$context_labels  = wp_list_pluck( $labels, 'singular_name' );
 
 		add_action( 'registered_taxonomy', array( __CLASS__, '_registered_taxonomy' ), 10, 3 );
 


### PR DESCRIPTION
As far as I can think, there's no need to have a pluralised category name anywhere. It makes more sense to have use the singular name as the context.

Here's a before and after shot (plural before, singular after):

![screen shot 2014-09-18 at 09 41 14](https://cloud.githubusercontent.com/assets/1097667/4313151/6de7b5ca-3ec4-11e4-92a9-75ea4734c10f.png)

@fjarrett Please review. Also, please try to think of a use case where a plural context would be required. I can't.

Resolves #608 .
