### PR TITLE
Prevent comment delete records when caused by a post delete

### DIFF
--- a/connectors/class-wp-stream-connector-comments.php
+++ b/connectors/class-wp-stream-connector-comments.php
@@ -320,6 +320,10 @@ class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 	 * @action before_delete_post
 	 */
 	public static function callback_before_delete_post( $post_id ) {
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
 		self::$delete_post = $post_id;
 	}
 
@@ -329,6 +333,10 @@ class WP_Stream_Connector_Comments extends WP_Stream_Connector {
 	 * @action deleted_post
 	 */
 	public static function callback_deleted_post( $post_id ) {
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
 		self::$delete_post = 0;
 	}
 


### PR DESCRIPTION
Resolves #652 

This PR prevents comment deleted records from being created when they are caused by a permanent post deletion.

In the future perhaps we can make this better to create a catchall record, but in my testing, this achieves our primary goal.

@lukecarbis @shadyvb Both of you please review this.
