### PR TITLE
Fix post revision action link by getting the adjacent revision

### DIFF
--- a/connectors/class-wp-stream-connector-posts.php
+++ b/connectors/class-wp-stream-connector-posts.php
@@ -110,7 +110,7 @@ class WP_Stream_Connector_Posts extends WP_Stream_Connector {
 				$revision_id = absint( wp_stream_get_meta( $record, 'revision_id', true ) );
 				$revision_id = self::get_adjacent_post_revision( $revision_id, false );
 
-				if ( wp_is_post_revision( $revision_id ) ) {
+				if ( $revision_id ) {
 					$links[ esc_html__( 'Revision', 'stream' ) ] = get_edit_post_link( $revision_id );
 				}
 			}
@@ -313,7 +313,7 @@ class WP_Stream_Connector_Posts extends WP_Stream_Connector {
 	 * @return int  $revision_id
 	 */
 	public static function get_adjacent_post_revision( $revision_id, $previous = true ) {
-		if ( ! wp_is_post_revision( $revision_id ) ) {
+		if ( empty( $revision_id ) || ! wp_is_post_revision( $revision_id ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Taking another stab at #585, this time using a workaround that finds the adjacent revision ID.

Unfortunately, the `revision_id` being saved as record meta is still incorrect. But this PR does fix the action link problem to arrive to the correct revision for that record.

![screen shot 2014-11-13 at 9 27 30 pm](https://cloud.githubusercontent.com/assets/522158/5040894/e7cf2fec-6b7b-11e4-927b-4402758f1013.png)

@shadyvb please review.
