### PR TITLE
Adding support for WP-CLI command

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -85,68 +85,12 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Subcommand to retreive details about your Stream account
-	 *
-	 * @subcommand account
-	 */
-	public function account() {
-		self::connection();
-
-		$site       = WP_Stream::$api->get_site();
-		$plan       = isset( $site->plan->type ) ? $site->plan->type : 'unknown';
-		$plan_label = ( 'free' === $plan ) ? __( 'Free', 'stream' ) : ( 'pro_monthly' === $plan ) ? __( 'Pro', 'stream' ) : ucwords( $plan );
-
-		WP_CLI::line( sprintf( __( 'Plan: %s', 'stream' ), $plan_label ) );
-
-		if ( 'free' !== $plan && 'pro_monthly' !== $plan ) {
-			return;
-		}
-
-		$retention   = isset( $site->plan->retention ) ? absint( $site->plan->retention ) : 0;
-		$retention   = ( 0 !== $retention ) ? sprintf( _n( '1 Day', '%s Days', $retention, 'stream' ), $retention ) : __( 'Unlimited', 'stream' );
-		$amount      = ! empty( $site->plan->amount ) ? $site->plan->amount : 0;
-		$expiry      = ! empty( $site->expiry->date ) ? $site->expiry->date : __( 'N/A', 'stream' );
-		$created     = isset( $site->created ) ? $site->created : null;
-		$date_format = get_option( 'date_format', 'F j, Y' );
-		$site_uuid   = get_option( 'wp_stream_site_uuid', null );
-		$api_key     = get_option( 'wp_stream_site_api_key', null );
-
-		WP_CLI::line( sprintf( __( 'Retention: %s', 'stream' ), $retention ) );
-
-		if ( 'free' !== $plan ) {
-			WP_CLI::line( sprintf( __( 'Next Billing: $%1$s on %2$s', 'stream' ), $amount, $expiry ) );
-		}
-
-		if ( $created ) {
-			WP_CLI::line( sprintf( __( 'Created: %s', 'stream' ), date_i18n( $date_format, strtotime( $created ) ) ) );
-		}
-
-		if ( $site_uuid ) {
-			WP_CLI::line( sprintf( __( 'Site ID: %s', 'stream' ), $site_uuid ) );
-		}
-
-		if ( $api_key ) {
-			WP_CLI::line( sprintf( __( 'API Key: %s', 'stream' ), $api_key ) );
-		}
-	}
-
-	/**
-	 * Subcommand for n00bs
-	 *
-	 * @subcommand help
-	 */
-	public function help() {
-		WP_CLI::line( __( 'Welcome to Stream for WP-CLI!', 'stream' ) );
-		WP_CLI::line( __( 'Available commands: query, account', 'stream' ) );
-	}
-
-	/**
 	 * Checks for a Stream connection and displays an error or success message
 	 *
 	 * @return void
 	 */
 	private static function connection() {
-		WP_CLI::line( __( 'Establishing secure connection with Stream...', 'stream' ) );
+		WP_CLI::line( __( 'Establishing secure connection with WP Stream...', 'stream' ) );
 
 		$query = wp_stream_query( array( 'records_per_page' => 1, 'fields' => 'created' ) );
 

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -28,7 +28,7 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 		}
 
 		if ( empty( $query_args['fields'] ) ) {
-			$defaults = array( 'created', 'ip', 'author_meta.user_login', 'author_role', 'summary' );
+			$defaults = array( 'created', 'ip', 'author', 'author_meta.user_login', 'author_role', 'summary' );
 
 			/**
 			 * Filter for default fields when arg is not provided

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -8,7 +8,7 @@
 class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 
 	/**
-	 * Query subcommand to retreive a list of activity records
+	 * Subcommand to query a set of Stream records
 	 *
 	 * You may use any associative argument(s) available in the
 	 * WP_Stream_Query::instance()->query() method.
@@ -21,6 +21,9 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	 * @subcommand query
 	 */
 	public function query( $args, $assoc_args ) {
+		self::is_connected();
+
+		$start      = microtime( true );
 		$query_args = array();
 
 		foreach ( $assoc_args as $key => $value ) {
@@ -44,7 +47,6 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 
 		if ( empty( $records ) ) {
 			WP_CLI::success( __( 'No results found.', 'stream' ) );
-
 			return;
 		}
 
@@ -76,9 +78,83 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 		}
 
 		$found   = count( $records );
-		$message = sprintf( _n( '1 result found.', '%s results found.', $found, 'stream' ), number_format( $found ) );
+		$stop    = microtime( true ) - $start;
+		$message = sprintf( _n( '1 result found in %s seconds.', '%s results found in %s seconds.', $found, 'stream' ), number_format( $found ), number_format( $stop, 4 ) );
 
 		WP_CLI::success( $message );
+	}
+
+	/**
+	 * Subcommand to retreive details about your Stream account
+	 *
+	 * @subcommand account
+	 */
+	public function account() {
+		self::is_connected();
+
+		$site       = WP_Stream::$api->get_site();
+		$plan       = isset( $site->plan->type ) ? $site->plan->type : 'unknown';
+		$plan_label = ( 'free' === $plan ) ? __( 'Free', 'stream' ) : ( 'pro_monthly' === $plan ) ? __( 'Pro', 'stream' ) : ucwords( $plan );
+
+		WP_CLI::line( sprintf( __( 'Plan: %s', 'stream' ), $plan_label ) );
+
+		if ( 'free' !== $plan && 'pro_monthly' !== $plan ) {
+			return;
+		}
+
+		$retention   = isset( $site->plan->retention ) ? absint( $site->plan->retention ) : 0;
+		$retention   = ( 0 !== $retention ) ? sprintf( _n( '1 Day', '%s Days', $retention, 'stream' ), $retention ) : __( 'Unlimited', 'stream' );
+		$amount      = ! empty( $site->plan->amount ) ? $site->plan->amount : 0;
+		$expiry      = ! empty( $site->expiry->date ) ? $site->expiry->date : __( 'N/A', 'stream' );
+		$created     = isset( $site->created ) ? $site->created : null;
+		$date_format = get_option( 'date_format', 'F j, Y' );
+		$site_uuid   = get_option( 'wp_stream_site_uuid', null );
+		$api_key     = get_option( 'wp_stream_site_api_key', null );
+
+		WP_CLI::line( sprintf( __( 'Retention: %s', 'stream' ), $retention ) );
+
+		if ( 'free' !== $plan ) {
+			WP_CLI::line( sprintf( __( 'Next Billing: $%1$s on %2$s', 'stream' ), $amount, $expiry ) );
+		}
+
+		if ( $created ) {
+			WP_CLI::line( sprintf( __( 'Created: %s', 'stream' ), date_i18n( $date_format, strtotime( $created ) ) ) );
+		}
+
+		if ( $site_uuid ) {
+			WP_CLI::line( sprintf( __( 'Site ID: %s', 'stream' ), $site_uuid ) );
+		}
+
+		if ( $api_key ) {
+			WP_CLI::line( sprintf( __( 'API Key: %s', 'stream' ), $api_key ) );
+		}
+	}
+
+	/**
+	 * Subcommand for n00bs
+	 *
+	 * @subcommand help
+	 */
+	public function help() {
+		WP_CLI::line( __( 'Welcome to Stream for WP-CLI!', 'stream' ) );
+		WP_CLI::line( __( 'Available commands: query, account', 'stream' ) );
+	}
+
+	/**
+	 * Does a small query to see if records are retrievable
+	 *
+	 * @return bool
+	 */
+	private static function is_connected() {
+		WP_CLI::line( __( 'Establishing secure connection with Stream...', 'stream' ) );
+
+		$query = wp_stream_query( array( 'records_per_page' => 1, 'fields' => 'created' ) );
+
+		if ( ! $query ) {
+			WP_CLI::error( __( 'SITE IS DISCONNECTED', 'stream' ) );
+		} else {
+			WP_CLI::success( __( 'SITE IS CONNECTED', 'stream' ) );
+		}
 	}
 
 }

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -51,13 +51,13 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 		$fields = array_map( 'trim', explode( ',', $query_args['fields'] ) );
 
 		foreach ( $records as $record ) {
-			$output   = '';
+			$output = '';
 
 			foreach ( $fields as $field ) {
-				$values  = wp_list_pluck( $records, $field );
+				$values = wp_list_pluck( $records, $field );
 
 				array_walk( $values, function( &$value ) {
-					$value = is_array( $value ) ? implode( ', ', $value ) : $value;
+					$value = is_array( $value ) ? $value[0] : $value;
 				});
 
 				$longest = max( array_map( 'strlen', $values ) );
@@ -65,7 +65,7 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 				$output .= $value;
 				$diff    = absint( $longest - strlen( $value ) );
 
-				for ( $i = 0;  $i < $diff; $i++ ) {
+				for ( $i = 0; $i < $diff; $i++ ) {
 					$output .= ' ';
 				}
 

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -18,7 +18,16 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 		}
 
 		if ( empty( $query_args['fields'] ) ) {
-			$query_args['fields'] = 'created,ip,author_meta.user_login,author_role,summary';
+			$defaults = array( 'created', 'ip', 'author_meta.user_login', 'author_role', 'summary' );
+
+			/**
+			 * Filter for default fields when arg is not provided
+			 *
+			 * @return array $defaults
+			 */
+			$defaults = apply_filters( 'wp_stream_wp_cli_default_fields', (array) $defaults );
+
+			$query_args['fields'] = implode( ',', array_map( 'trim', $defaults ) );
 		}
 
 		$records = wp_stream_query( $query_args );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -43,10 +43,8 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 
 				$longest = max( array_map( 'strlen', $values ) );
 				$value   = is_array( $record->$field ) ? implode( ', ', $record->$field ) : $record->$field;
-
 				$output .= $value;
-
-				$diff = absint( $longest - strlen( $value ) );
+				$diff    = absint( $longest - strlen( $value ) );
 
 				for ( $i = 0;  $i < $diff; $i++ ) {
 					$output .= ' ';
@@ -55,9 +53,7 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 				$output .= '   ';
 			}
 
-			$output = trim( $output );
-
-			WP_CLI::line( $output );
+			WP_CLI::line( trim( $output ) );
 		}
 
 		$found   = count( $records );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -10,8 +10,12 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Query subcommand to retreive a list of activity records
 	 *
-	 * You may use any associative argument available in the
-	 * WP_Stream_Query object.
+	 * You may use any associative argument(s) available in the
+	 * WP_Stream_Query::instance()->query() method.
+	 *
+	 * Examples:
+	 * wp stream query --author_role__not_in=administrator --date_after=2015-01-01T12:00:00
+	 * wp stream query --author=1 --action=login --records_per_page=50 --fields=created
 	 *
 	 * @see WP_Stream_Query
 	 * @subcommand query

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -21,7 +21,7 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	 * @subcommand query
 	 */
 	public function query( $args, $assoc_args ) {
-		self::is_connected();
+		self::connection();
 
 		$start      = microtime( true );
 		$query_args = array();
@@ -90,7 +90,7 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	 * @subcommand account
 	 */
 	public function account() {
-		self::is_connected();
+		self::connection();
 
 		$site       = WP_Stream::$api->get_site();
 		$plan       = isset( $site->plan->type ) ? $site->plan->type : 'unknown';
@@ -141,11 +141,11 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Does a small query to see if records are retrievable
+	 * Checks for a Stream connection and displays an error or success message
 	 *
-	 * @return bool
+	 * @return void
 	 */
-	private static function is_connected() {
+	private static function connection() {
 		WP_CLI::line( __( 'Establishing secure connection with Stream...', 'stream' ) );
 
 		$query = wp_stream_query( array( 'records_per_page' => 1, 'fields' => 'created' ) );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -8,9 +8,16 @@
 class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 
 	/**
-	 * @subcommand log
+	 * Query subcommand to retreive a list of activity records
+	 *
+	 * You may use any associative argument available in the
+	 * WP_Stream_Query object.
+	 *
+	 * @see WP_Stream_Query
+	 * @subcommand query
+	 * @synopsis [--arg=<key>]
 	 */
-	public function log( $args, $assoc_args ) {
+	public function query( $args, $assoc_args ) {
 		$query_args = array();
 
 		foreach ( $assoc_args as $key => $value ) {

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -19,7 +19,6 @@ class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
 	 *
 	 * @see WP_Stream_Query
 	 * @subcommand query
-	 * @synopsis [--arg=<key>]
 	 */
 	public function query( $args, $assoc_args ) {
 		$query_args = array();

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Stream commands for WP-CLI
+ *
+ * @since 2.0.3
+ * @see https://github.com/wp-cli/wp-cli
+ */
+class WP_Stream_WP_CLI_Command extends WP_CLI_Command {
+
+	/**
+	 * @subcommand log
+	 */
+	public function log( $args, $assoc_args ) {
+		$query_args = array();
+
+		foreach ( $assoc_args as $key => $value ) {
+			$query_args[ $key ] = $value;
+		}
+
+		$records = wp_stream_query( $query_args );
+
+		if ( empty( $records ) ) {
+			WP_CLI::success( __( 'No results found.', 'stream' ) );
+
+			return;
+		}
+
+		foreach ( $records as $record ) {
+			if ( ! empty( $assoc_args['fields'] ) ) {
+				$fields = array_map( 'trim', explode( ',', $assoc_args['fields'] ) );
+				$output = '';
+
+				foreach ( $fields as $field ) {
+					$output .= isset( $record->$field ) ? is_array( $record->$field ) ? implode( ', ', $record->$field ) : $record->$field : null;
+					$output .= '   ';
+				}
+			} else {
+				$author = new WP_Stream_Author( (int) $record->author, (array) $record->author_meta );
+				$output = sprintf( '%s   %s   %s (%d)   %s', $record->created, $record->ip, $author->get_display_name(), $record->author, $record->summary );
+			}
+
+			$output = trim( $output );
+
+			WP_CLI::line( $output );
+		}
+
+		$total   = count( $records );
+		$message = sprintf( _n( '1 result found.', '%s results found.', $total, 'stream' ), $total );
+
+		WP_CLI::success( $message );
+	}
+
+}

--- a/stream.php
+++ b/stream.php
@@ -39,6 +39,13 @@ class WP_Stream {
 	const VERSION = '2.0.2';
 
 	/**
+	 * WP-CLI command
+	 *
+	 * @const string
+	 */
+	const WP_CLI_COMMAND = 'stream';
+
+	/**
 	 * Hold Stream instance
 	 *
 	 * @var string
@@ -143,6 +150,13 @@ class WP_Stream {
 			add_action( 'plugins_loaded', array( 'WP_Stream_Pointers', 'load' ) );
 
 			add_action( 'plugins_loaded', array( 'WP_Stream_Migrate', 'load' ) );
+		}
+
+		// Load WP-CLI command
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once WP_STREAM_INC_DIR . 'wp-cli.php';
+
+			WP_CLI::add_command( self::WP_CLI_COMMAND, 'WP_Stream_WP_CLI_Command' );
 		}
 	}
 


### PR DESCRIPTION
Implements #499 

I'd like to get this out in it's most basic form first, and improve on it later down the line.

The scope of this PR does not address `tail` or `export` args which could certainly be added in the future.

Right now there is only a `query` subcommand and it will accept any associative argument(s) that the `WP_Stream_Query::instance()->query()` method accepts. You can add as many of these as you'd like in parallel.

**Some examples:**

```
wp stream query
wp stream query --author=1
wp stream query --author=1 --records_per_page=20
wp stream query --author=1 --action=login --date_before=2015-01-15 --order=asc
wp stream query --author_role__not_in=administrator,editor
```

If you don't like the output format you could also specify which fields you want to output to the console using the `--fields` arg, adding multiple fields in a comma separated list.

**Some examples:**

```
wp stream query --author=1 --fields=summary
wp stream query --author=1 --fields=created,ip,summary
wp stream query --author_role=editor --date_before=2015-01-01T12:00:00 --fields=created,context,action,summary
```

The fields for default output are also filterable, so you can do:

```php
add_filter( 'wp_stream_wp_cli_default_fields', function() {
	return array( 'created', 'author_meta.display_name', 'context', 'action' );
});
```

**Update 2015-01-16**

I have added two new subcommands that accept no arguments: `wp stream account` and `wp stream help`