### PR TITLE
Order searches by date desc by default, instead of by _score

### DIFF
--- a/classes/class-wp-stream-query.php
+++ b/classes/class-wp-stream-query.php
@@ -46,7 +46,7 @@ class WP_Stream_Query {
 			'paged'                 => 1,
 			// Order
 			'order'                 => 'desc',
-			'orderby'               => isset( $args['search'] ) ? '_score' : 'date',
+			'orderby'               => 'date',
 			// Meta/Taxonomy sub queries
 			'meta'                  => array(),
 			// Data aggregations


### PR DESCRIPTION
Resolves #689

@lukecarbis Please test this out.