### PR TITLE
Add global hooks even if user is excluded

### DIFF
--- a/classes/class-wp-stream-connector.php
+++ b/classes/class-wp-stream-connector.php
@@ -34,6 +34,15 @@ abstract class WP_Stream_Connector {
 		foreach ( $class::$actions as $action ) {
 			add_action( $action, array( $class, 'callback' ), null, 5 );
 		}
+	}
+
+	/**
+	 * Register hooks that are needed even if the plugin is not activated
+	 *
+	 * @return void
+	 */
+	public static function register_global_hooks() {
+		$class = get_called_class();
 
 		add_filter( 'wp_stream_action_links_' . $class::$name, array( $class, 'action_links' ), 10, 2 );
 	}

--- a/classes/class-wp-stream-connectors.php
+++ b/classes/class-wp-stream-connectors.php
@@ -124,7 +124,7 @@ class WP_Stream_Connectors {
 			$is_excluded_connector = apply_filters( 'wp_stream_check_connector_is_excluded', $is_excluded, $connector_name, $excluded_connectors );
 
 			$connector::register_global_hooks();
-			
+
 			if ( $is_excluded_connector ) {
 				continue;
 			}

--- a/classes/class-wp-stream-connectors.php
+++ b/classes/class-wp-stream-connectors.php
@@ -123,6 +123,8 @@ class WP_Stream_Connectors {
 			 */
 			$is_excluded_connector = apply_filters( 'wp_stream_check_connector_is_excluded', $is_excluded, $connector_name, $excluded_connectors );
 
+			$connector::register_global_hooks();
+			
 			if ( $is_excluded_connector ) {
 				continue;
 			}


### PR DESCRIPTION
Right now if the logging process is disabled for a particular user in Stream settings the user will not see any actions links on Stream list page because connectors are not loaded for him.

![screen shot 2015-03-02 at 11 18 13 am](https://cloud.githubusercontent.com/assets/1933681/6444804/f66ef4cc-c0cd-11e4-98a8-3263cfba1e4a.png)

------

![screen_shot_2015-03-02_at_11_22_30_am](https://cloud.githubusercontent.com/assets/1933681/6444910/a0923522-c0ce-11e4-90d0-1bec853cd200.png)


I propose adding a a global function that will load actions and filters from connectors that need to be loaded even if the logging is disabled for a particular user.
