### PR TITLE
Must load Reports on plugins_loaded for date range filter to work

### DIFF
--- a/extensions/reports/class-wp-stream-reports.php
+++ b/extensions/reports/class-wp-stream-reports.php
@@ -54,7 +54,8 @@ class WP_Stream_Reports {
 			return;
 		}
 
-		add_action( 'init', array( $this, 'load' ) );
+		// Must be fired on plugins_loaded for date range filters to work properly
+		add_action( 'plugins_loaded', array( $this, 'load' ) );
 	}
 
 	/**


### PR DESCRIPTION
This bug was introduced as part of `2.0.3` in https://github.com/wp-stream/stream/commit/79e0288c0358aba6e767a25330f17851ca88c87b.

It caused the screen to go blank with a `0` in the upper left when attempting to change the date range filter on the Reports screen.

![screen shot 2015-04-23 at 10 26 47 am](https://cloud.githubusercontent.com/assets/522158/7300686/454a778a-e9a3-11e4-9cec-74cdf32c607b.png)