### PR TITLE
Don't generate unused rewrite rules for alerts post type

### DIFF
--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -358,6 +358,7 @@ class Alerts {
 			'description'         => __( 'Alerts for Stream.', 'stream' ),
 			'public'              => false,
 			'publicly_queryable'  => false,
+			'rewrite'             => false,
 			'exclude_from_search' => true,
 			'show_ui'             => true,
 			'show_in_menu'        => false, // @see modify_admin_menu


### PR DESCRIPTION
`register_post_type()` generates rewrite rules by default even if the post type isn't public. Two avoid this we can pass `'rewrite' => false`.

Currently the `rewrite_rules` options also contains these rules:

```
  'wp_stream_alerts/[^/]+/attachment/([^/]+)/?$' => 'index.php?attachment=$matches[1]',
  'wp_stream_alerts/[^/]+/attachment/([^/]+)/trackback/?$' => 'index.php?attachment=$matches[1]&tb=1',
  'wp_stream_alerts/[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?attachment=$matches[1]&feed=$matches[2]',
  'wp_stream_alerts/[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?attachment=$matches[1]&feed=$matches[2]',
  'wp_stream_alerts/[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$' => 'index.php?attachment=$matches[1]&cpage=$matches[2]',
  'wp_stream_alerts/[^/]+/attachment/([^/]+)/embed/?$' => 'index.php?attachment=$matches[1]&embed=true',
  'wp_stream_alerts/([^/]+)/embed/?$' => 'index.php?wp_stream_alerts=$matches[1]&embed=true',
  'wp_stream_alerts/([^/]+)/trackback/?$' => 'index.php?wp_stream_alerts=$matches[1]&tb=1',
  'wp_stream_alerts/([^/]+)/page/?([0-9]{1,})/?$' => 'index.php?wp_stream_alerts=$matches[1]&paged=$matches[2]',
  'wp_stream_alerts/([^/]+)/comment-page-([0-9]{1,})/?$' => 'index.php?wp_stream_alerts=$matches[1]&cpage=$matches[2]',
  'wp_stream_alerts/([^/]+)(?:/([0-9]+))?/?$' => 'index.php?wp_stream_alerts=$matches[1]&page=$matches[2]',
  'wp_stream_alerts/[^/]+/([^/]+)/?$' => 'index.php?attachment=$matches[1]',
  'wp_stream_alerts/[^/]+/([^/]+)/trackback/?$' => 'index.php?attachment=$matches[1]&tb=1',
  'wp_stream_alerts/[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?attachment=$matches[1]&feed=$matches[2]',
  'wp_stream_alerts/[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?attachment=$matches[1]&feed=$matches[2]',
  'wp_stream_alerts/[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$' => 'index.php?attachment=$matches[1]&cpage=$matches[2]',
  'wp_stream_alerts/[^/]+/([^/]+)/embed/?$' => 'index.php?attachment=$matches[1]&embed=true',
```

With this change the above rules will be removed.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Don't generate unused rewrite rules for alerts post type.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
