### PR TITLE
Comments Connector: Avoid a PHP Warning on pingbacks.

### DIFF
--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -194,10 +194,10 @@ class Connector_Comments extends Connector {
 			$user_name = isset( $user->display_name ) ? $user->display_name : $comment->comment_author;
 		}
 
-		if ( $req_user_login && isset( $comment->user_id ) ) {
+		if ( $req_user_login && ! empty( $comment->user_id ) ) {
 			$user      = get_user_by( 'id', $comment->user_id );
-			$user_id   = $user->ID;
-			$user_name = $user->display_name;
+			$user_id   = isset( $user->ID ) ? $user->ID : 0;
+			$user_name = isset( $user->display_name ) ? $user->display_name : $comment->comment_author;
 		}
 
 		if ( 'id' === $field ) {

--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -195,9 +195,11 @@ class Connector_Comments extends Connector {
 		}
 
 		if ( $req_user_login && ! empty( $comment->user_id ) ) {
-			$user      = get_user_by( 'id', $comment->user_id );
-			$user_id   = isset( $user->ID ) ? $user->ID : 0;
-			$user_name = isset( $user->display_name ) ? $user->display_name : $comment->comment_author;
+			$user = get_user_by( 'id', $comment->user_id );
+			if ( $user ) {
+				$user_id   = $user->ID;
+				$user_name = $user->display_name;
+			}
 		}
 
 		if ( 'id' === $field ) {


### PR DESCRIPTION
A PHP Warning is triggered on sites that require comment registrations, during pingback creations.

Eg.
```
E_WARNING: Attempt to read property "display_name" on bool in /wp-content/plugins/stream/connectors/class-connector-comments.php:200
Source: POST https://example.org/xmlrpc.php
UA: The Incutio XML-RPC PHP Library -- WordPress/6.7.2
Filter stack: wp_insert_comment
```

This is because `WP_Comment->user_id` will always exist, although it may be empty.

This PR does two things:
 - Check that the user_id is empty (ie. not 0)
 - Copies over the existing logic for when a user can't be found via email, in the event the user object can't be found.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Avoid triggering PHP Warnings under PHP 8.x


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
