### PR TITLE
Add missing workflow trigger

### DIFF
--- a/.github/workflows/deploy-to-stream-dist.yml
+++ b/.github/workflows/deploy-to-stream-dist.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - develop
+  release:
+    types: [published]
 
 jobs:
   lint_and_test:


### PR DESCRIPTION
Fixes [#1818](https://github.com/xwp/stream/issues/1818).

## Release Changelog

- Fix: Add missing workflow trigger so that the latest versions of the code are published on `stream-dist` and tagged properly