### PR TITLE
chore: replace uuid with native crypto.randomUUID()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,7 @@
         "copy-webpack-plugin": "^14.0.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "jquery": "3.7.1",
-        "npm-run-all2": "^8.0.4",
-        "uuid": "^11.1.1"
+        "npm-run-all2": "^8.0.4"
       },
       "engines": {
         "node": "^22.22.2"
@@ -21272,20 +21271,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "copy-webpack-plugin": "^14.0.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "jquery": "3.7.1",
-    "npm-run-all2": "^8.0.4",
-    "uuid": "^11.1.1"
+    "npm-run-all2": "^8.0.4"
   },
   "scripts": {
     "build": "wp-scripts build",

--- a/tests/e2e/editor-new-post.spec.js
+++ b/tests/e2e/editor-new-post.spec.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { v4 as uuidv4 } from 'uuid';
-
-/**
  * WordPress dependencies
  */
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
@@ -14,8 +9,7 @@ test.describe( 'Editor: saving a new post', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 
-		const uuid = uuidv4();
-		postTitle = `Test Post ${ uuid }`; // Sometimes this runs more than once within a microsecond so it's a UUID.
+		postTitle = `Test Post ${ crypto.randomUUID() }`; // Sometimes this runs more than once within a microsecond so it's a UUID.
 
 		// eslint-disable-next-line no-console
 		console.log( `New post ${ postTitle }` );


### PR DESCRIPTION
## Summary

Removes the `uuid` devDependency in favour of the built-in `crypto.randomUUID()`.

## Why

- `uuid` was used in exactly one place (`tests/e2e/editor-new-post.spec.js`) to generate a unique post title for a Playwright test.
- Node 22+ and all modern browsers expose `crypto.randomUUID()` globally — no dependency required.
- **Unblocks #1861 / XWPENG-29:** `uuid` v14 ships ESM-only (drops the `require` export condition). The currently bundled `eslint-import-resolver-node@0.3.9` (transitively via `@wordpress/eslint-plugin@22.22.0`) doesn't understand the `exports` field, so `npm run lint:js` fails with:

  ```
  Unable to resolve path to module 'uuid'  import/no-unresolved
  ```

  Removing `uuid` sidesteps the resolver upgrade entirely.

## Changes

- `package.json`: removed `"uuid": "^11.1.1"` from `devDependencies`.
- `package-lock.json`: regenerated; `uuid` entry dropped.
- `tests/e2e/editor-new-post.spec.js`: removed `import { v4 as uuidv4 } from 'uuid'`; replaced `uuidv4()` with `crypto.randomUUID()`.

## Verification

- `npm ci` — OK
- `npm run lint:js` — clean
- `npm run build` — OK; `build/select2/*` and `build/timeago/*` assets present
- `node -e "console.log(crypto.randomUUID())"` — OK on Node 22

## Related

- Closes #1861 (chore(deps): update dependency uuid to v14) — supersedes that approach.
- Refs XWPENG-29 (Stream plugin: dependency cleanup).