### PR TITLE
fix(e2e): repair new-post spec and add Playwright E2E job to CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -132,37 +132,28 @@ jobs:
       - name: Start WordPress
         run: npm run start
 
-      - name: Wait for MySQL
+      - name: Wait for MySQL and WordPress
         run: |
-          for i in {1..60}; do
-            if docker compose exec -T mysql mariadb -uwordpress -ppassword wordpress -e 'SELECT 1' >/dev/null 2>&1; then
-              echo "MySQL is accepting connections."
-              exit 0
-            fi
-            echo "Waiting for MySQL... ($i)"
-            sleep 2
-          done
-          echo "MySQL did not become ready in time." >&2
-          docker compose logs --tail=50 mysql >&2 || true
-          exit 1
+          php -r '
+            require "vendor/autoload.php";
+            foreach ( [ [ "127.0.0.1", 3306, "MySQL" ], [ "127.0.0.1", 80, "WordPress" ] ] as $svc ) {
+              [ $host, $port, $name ] = $svc;
+              try {
+                ( new XWP\Wait_For\Tcp_Connection( $host, $port ) )->connect( 120 );
+                fwrite( STDOUT, "$name is accepting connections on $host:$port.\n" );
+              } catch ( Throwable $e ) {
+                fwrite( STDERR, "$name not ready: " . $e->getMessage() . "\n" );
+                exit( 1 );
+              }
+            }
+          '
 
-      - name: Wait for WordPress HTTP
+      - name: Dump container state on failure
+        if: failure()
         run: |
-          for i in {1..60}; do
-            status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 5 http://stream.wpenv.net/ || echo "000")
-            if [ "$status" != "000" ]; then
-              echo "WordPress is reachable (HTTP $status)."
-              exit 0
-            fi
-            echo "Waiting for WordPress... ($i) status=$status"
-            sleep 2
-          done
-          echo "WordPress did not become reachable in time. Last status: $status" >&2
-          echo "--- docker compose ps ---" >&2
-          docker compose ps >&2 || true
-          echo "--- wordpress container logs (tail) ---" >&2
-          docker compose logs --tail=80 wordpress >&2 || true
-          exit 1
+          docker compose ps || true
+          docker compose logs --tail=80 mysql || true
+          docker compose logs --tail=80 wordpress || true
 
       - name: Install WordPress multisite
         run: npm run install-wordpress

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -135,14 +135,15 @@ jobs:
       - name: Wait for MySQL
         run: |
           for i in {1..60}; do
-            if docker compose exec -T mysql mariadb-admin ping -h localhost -ppassword --silent; then
-              echo "MySQL is up."
+            if docker compose exec -T mysql mariadb -uwordpress -ppassword wordpress -e 'SELECT 1' >/dev/null 2>&1; then
+              echo "MySQL is accepting connections."
               exit 0
             fi
             echo "Waiting for MySQL... ($i)"
             sleep 2
           done
           echo "MySQL did not become ready in time." >&2
+          docker compose logs --tail=50 mysql >&2 || true
           exit 1
 
       - name: Wait for WordPress HTTP

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -2,11 +2,16 @@ name: Lint and Test
 
 on: [push, workflow_call]
 
+env:
+  # Opt into Node.js 24 for JavaScript actions that still ship a Node 20 runtime.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
 
   lint:
     name: Lint and Test
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: read
@@ -39,7 +44,7 @@ jobs:
           restore-keys: ${{ runner.os }}-php-
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,6 +71,7 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-22.04
+    timeout-minutes: 12
     needs: lint
     permissions:
       contents: read
@@ -85,7 +91,7 @@ jobs:
         run: echo "127.0.0.1 stream.wpenv.net" | sudo tee -a /etc/hosts
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -109,7 +115,7 @@ jobs:
       - name: Wait for MySQL
         run: |
           for i in {1..60}; do
-            if docker compose exec -T mysql mysqladmin ping -h localhost -ppassword --silent; then
+            if docker compose exec -T mysql mariadb-admin ping -h localhost -ppassword --silent; then
               echo "MySQL is up."
               exit 0
             fi

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -62,3 +62,86 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-22.04
+    needs: lint
+    permissions:
+      contents: read
+      packages: read
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Map stream.wpenv.net to localhost
+        run: echo "127.0.0.1 stream.wpenv.net" | sudo tee -a /etc/hosts
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+
+      - name: Pull custom Docker images
+        run: docker compose pull wordpress
+
+      - name: Start WordPress
+        run: npm run start
+
+      - name: Wait for MySQL
+        run: |
+          for i in {1..60}; do
+            if docker compose exec -T mysql mysqladmin ping -h localhost -ppassword --silent; then
+              echo "MySQL is up."
+              exit 0
+            fi
+            echo "Waiting for MySQL... ($i)"
+            sleep 2
+          done
+          echo "MySQL did not become ready in time." >&2
+          exit 1
+
+      - name: Wait for WordPress HTTP
+        run: |
+          for i in {1..60}; do
+            if curl --silent --output /dev/null --fail --resolve stream.wpenv.net:80:127.0.0.1 http://stream.wpenv.net/; then
+              echo "WordPress is reachable."
+              exit 0
+            fi
+            echo "Waiting for WordPress... ($i)"
+            sleep 2
+          done
+          echo "WordPress did not become reachable in time." >&2
+          exit 1
+
+      - name: Install WordPress multisite
+        run: npm run install-wordpress
+
+      - name: Run E2E tests
+        run: npm run test-e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -148,18 +148,18 @@ jobs:
             echo "WordPress is accepting connections on 127.0.0.1:80.\n";
           '
 
+      - name: Install WordPress multisite
+        run: npm run install-wordpress
+
+      - name: Run E2E tests
+        run: npm run test-e2e
+
       - name: Dump container state on failure
         if: failure()
         run: |
           docker compose ps || true
           docker compose logs --tail=80 mysql || true
           docker compose logs --tail=80 wordpress || true
-
-      - name: Install WordPress multisite
-        run: npm run install-wordpress
-
-      - name: Run E2E tests
-        run: npm run test-e2e
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -87,6 +87,23 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ hashFiles( 'composer.lock' ) }}
+          restore-keys: ${{ runner.os }}-php-
+
       - name: Map stream.wpenv.net to localhost
         run: echo "127.0.0.1 stream.wpenv.net" | sudo tee -a /etc/hosts
 
@@ -99,6 +116,9 @@ jobs:
 
       - name: Install NPM dependencies
         run: npm install
+
+      - name: Install Composer dependencies
+        run: composer install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -132,20 +132,20 @@ jobs:
       - name: Start WordPress
         run: npm run start
 
-      - name: Wait for MySQL and WordPress
+      - name: Wait for MySQL (from inside the wordpress container)
+        run: |
+          npm run cli -- php -r '
+            require "/var/www/html/wp-content/plugins/stream-src/vendor/autoload.php";
+            ( new XWP\Wait_For\Tcp_Connection( "mysql", 3306 ) )->connect( 120 );
+            echo "MySQL is accepting connections on mysql:3306.\n";
+          '
+
+      - name: Wait for WordPress (from the runner)
         run: |
           php -r '
             require "vendor/autoload.php";
-            foreach ( [ [ "127.0.0.1", 3306, "MySQL" ], [ "127.0.0.1", 80, "WordPress" ] ] as $svc ) {
-              [ $host, $port, $name ] = $svc;
-              try {
-                ( new XWP\Wait_For\Tcp_Connection( $host, $port ) )->connect( 120 );
-                fwrite( STDOUT, "$name is accepting connections on $host:$port.\n" );
-              } catch ( Throwable $e ) {
-                fwrite( STDERR, "$name not ready: " . $e->getMessage() . "\n" );
-                exit( 1 );
-              }
-            }
+            ( new XWP\Wait_For\Tcp_Connection( "127.0.0.1", 80 ) )->connect( 60 );
+            echo "WordPress is accepting connections on 127.0.0.1:80.\n";
           '
 
       - name: Dump container state on failure

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -128,14 +128,19 @@ jobs:
       - name: Wait for WordPress HTTP
         run: |
           for i in {1..60}; do
-            if curl --silent --output /dev/null --fail --resolve stream.wpenv.net:80:127.0.0.1 http://stream.wpenv.net/; then
-              echo "WordPress is reachable."
+            status=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 5 http://stream.wpenv.net/ || echo "000")
+            if [ "$status" != "000" ]; then
+              echo "WordPress is reachable (HTTP $status)."
               exit 0
             fi
-            echo "Waiting for WordPress... ($i)"
+            echo "Waiting for WordPress... ($i) status=$status"
             sleep 2
           done
-          echo "WordPress did not become reachable in time." >&2
+          echo "WordPress did not become reachable in time. Last status: $status" >&2
+          echo "--- docker compose ps ---" >&2
+          docker compose ps >&2 || true
+          echo "--- wordpress container logs (tail) ---" >&2
+          docker compose logs --tail=80 wordpress >&2 || true
           exit 1
 
       - name: Install WordPress multisite

--- a/tests/e2e/editor-new-post.spec.js
+++ b/tests/e2e/editor-new-post.spec.js
@@ -1,61 +1,85 @@
 /**
  * WordPress dependencies
  */
-import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { test, expect, Editor } from '@wordpress/e2e-test-utils-playwright';
 
 test.describe( 'Editor: saving a new post', () => {
-	let page, postTitle, postId;
+	let page, editor, postTitle, postId;
 
 	test.beforeAll( async ( { browser } ) => {
+		test.setTimeout( 90_000 );
+
 		page = await browser.newPage();
+		editor = new Editor( { page } );
 
 		postTitle = `Test Post ${ crypto.randomUUID() }`; // Sometimes this runs more than once within a microsecond so it's a UUID.
 
 		// eslint-disable-next-line no-console
 		console.log( `New post ${ postTitle }` );
 
-		// Even though we're using WP's npm package, it's more straightforward to do it this way, at least for me in this environment.
+		// The shared setup deactivates Stream. Reactivate it so the publish action is logged.
+		await page.goto( 'http://stream.wpenv.net/wp-admin/network/plugins.php' );
+		const activateLink = page.getByLabel( 'Network Activate Stream' );
+		if ( await activateLink.isVisible().catch( () => false ) ) {
+			await activateLink.click();
+			await page.waitForURL( /plugins\.php/ );
+		}
+
 		await page.goto( 'http://stream.wpenv.net/wp-admin/post-new.php' );
-		await page.getByLabel( 'Add title' ).click();
-		await page.getByLabel( 'Add title' ).fill( postTitle );
-		await page.getByLabel( 'Add title' ).press( 'Tab' );
-		await page.getByLabel( 'Empty block; start writing or' ).fill( 'I\'m a test post' );
-		await page.getByRole( 'button', { name: 'Publish', exact: true } ).click();
+
+		// Wait for Gutenberg to be ready.
+		await page.waitForFunction( () => window?.wp?.blocks && window?.wp?.data );
+
+		// Dismiss the welcome dialog if it appears.
+		const welcomeClose = page.getByRole( 'dialog', { name: 'Welcome to the editor' } ).getByRole( 'button', { name: 'Close' } );
+		if ( await welcomeClose.isVisible().catch( () => false ) ) {
+			await welcomeClose.click();
+		}
+
+		// Set the title via the data layer, and the body via the editor helper.
+		await page.evaluate( ( title ) => {
+			window.wp.data.dispatch( 'core/editor' ).editPost( { title } );
+		}, postTitle );
+		await editor.setContent( '<!-- wp:paragraph --><p>I\'m a test post</p><!-- /wp:paragraph -->' );
+
+		// Publish; the helper handles the pre-publish panel and waits for the published snackbar.
+		await editor.publishPost();
 
 		postId = await page.locator( 'input#post_ID' ).inputValue();
 
 		// eslint-disable-next-line no-console
 		console.log( `Post ID: ${ postId }` );
 
-		// We need to wait for both of the editor responses! The post saves to the posts table then the metadata saves to postmeta.
-		await Promise.all( [
-			page.waitForResponse( ( resp ) => resp.url().includes( 'meta-box-loader' ) && resp.status() === 302 ),
-			page.waitForResponse( ( resp ) => resp.url().includes( `wp-json/wp/v2/posts/${ postId }` ) && resp.status() === 200 ),
-			page.getByLabel( 'Editor publish' ).getByRole( 'button', { name: 'Publish', exact: true } ).click(),
-		] );
-
-		// They are too much in the posts table so I'm deleting them.
-		await page.goto( 'http://stream.wpenv.net/wp-admin/edit.php?post_type=post' );
-		const listTable = page.getByRole( 'table', { name: 'Table ordered by' } );
-		await expect( listTable ).toBeVisible();
-
-		// Move post to trash.
-		await listTable.getByRole( 'link', { name: `“${ postTitle }” (Edit)` } ).hover();
-		await listTable.getByRole( 'link', { name: `Move “${ postTitle }” to the Trash` } ).click();
-
-		// Ok, we're all set up, let's go to our page.
+		// Go straight to the Stream log so the assertions below can check the published row.
 		await page.goto( 'http://stream.wpenv.net/wp-admin/admin.php?page=wp_stream' );
 	} );
 
-	// Do we have a published row?
+	test.afterAll( async () => {
+		// Clean up the published post so it doesn't accumulate in the posts table.
+		if ( postId ) {
+			await page.goto( `http://stream.wpenv.net/wp-admin/post.php?post=${ postId }&action=trash&_wpnonce=` ).catch( () => {} );
+			await page.goto( 'http://stream.wpenv.net/wp-admin/edit.php?post_type=post' );
+			const trashLink = page.getByRole( 'link', { name: `Move “${ postTitle }” to the Trash` } );
+			if ( await trashLink.isVisible().catch( () => false ) ) {
+				await page.getByRole( 'link', { name: `“${ postTitle }” (Edit)` } ).hover();
+				await trashLink.click();
+			}
+		}
+
+		// Restore the deactivated state expected by other test files.
+		await page.goto( 'http://stream.wpenv.net/wp-admin/network/plugins.php' );
+		const deactivateLink = page.getByLabel( 'Network Deactivate Stream' );
+		if ( await deactivateLink.isVisible().catch( () => false ) ) {
+			await deactivateLink.click();
+		}
+		await page.close();
+	} );
+
 	test( 'has published row', async () => {
-		// Expects Stream log to have "Test Post" post published visible.
 		await expect( page.getByText( `"${ postTitle }" post published` ) ).toBeVisible();
 	} );
 
-	// We should not have an updated row. This times out which makes it fail.
 	test( 'does not have updated row', async () => {
-		// Expects Stream log to have "Test Post" post published visible.
 		await expect( page.getByText( `"${ postTitle }" post updated` ) ).not.toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## Summary

Fixes the long-standing failures in `tests/e2e/editor-new-post.spec.js` and wires the Playwright E2E suite into CI so future regressions are caught automatically. The spec assumed a 1-step Publish flow, a title locator that is no longer top-level, and a `meta-box-loader` response that is never fired (no meta boxes are registered for posts in this environment). It also did not account for the shared setup deactivating the Stream plugin, which suppressed the very log entries the test asserts on.

## Changes

- Replace hand-rolled iframe and `getByLabel('Add title')` selectors with the official `@wordpress/e2e-test-utils-playwright` `Editor` helpers (`setContent`, `publishPost`).
- Dismiss the Gutenberg first-visit welcome dialog when present.
- Reactivate Stream in `beforeAll` so the publish action is captured by the Stream log, and deactivate it again in `afterAll` to preserve the preconditions of `network-activated.spec.js`.
- Remove the obsolete `meta-box-loader` and `wp/v2/posts/<id>` race; `publishPost()` waits for the published snackbar.
- Move post cleanup into `afterAll` so a failed test doesn't leave a stray draft.
- New `e2e` job that runs after `lint` succeeds.
- Maps `stream.wpenv.net` to `127.0.0.1` so the existing hardcoded URLs resolve in CI.
- Installs Composer dependencies (wp-cli ships via `wp-cli/wp-cli-bundle` into `vendor/bin`, on the WP container's PATH) and Playwright's Chromium with system deps; builds the plugin so `build/` is populated; starts the Docker stack.
- Uses the already-vendored `xwp/wait-for` library for readiness probes: MySQL is probed from inside the wordpress container (it connects over the docker network to `mysql:3306`, not via the host port mapping), and WordPress is probed from the runner.
- Runs `wp core multisite-install`, then `npm run test-e2e`.
- Dumps `docker compose ps` and recent container logs on failure.
- Uploads the `playwright-report` directory as a workflow artifact (including on failure) for easier triage.
- Adds `timeout-minutes` (lint 10, e2e 12) so a hung step fails fast.
- Bumps `docker/login-action` to v3 and sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to ride out the Node 20 deprecation in GitHub-hosted runners. The env var can be removed after June 2, 2026 when Node 24 becomes the runner default.

## Validation

- `npx playwright test tests/e2e/editor-new-post.spec.js` locally: 3/3 pass.
- `npx playwright test` locally: 5/5 pass (full suite including `network-activated.spec.js`).
- `npm run lint:js` locally: no output.
- The new CI job ran on this branch end-to-end; lint, build, PHPUnit, and Playwright steps all completed successfully.

Closes #1872