### PR TITLE
chore(deps): bump composer/installers to v2 and mercator to dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
   "require": {
     "php": ">=7.2",
     "ext-json": "*",
-    "composer/installers": "~1.0",
+    "composer/installers": "^1.0 || ^2.0",
     "woocommerce/action-scheduler": "^3.9"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-    "humanmade/mercator": "^1.0",
+    "humanmade/mercator": "dev-master as 1.1.0",
     "johnbillion/query-monitor": "^3.16",
     "php-coveralls/php-coveralls": "^2.5",
     "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",

--- a/composer.lock
+++ b/composer.lock
@@ -4,43 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1722ffe23b8e9b94e6c3e54fbec2a350",
+    "content-hash": "a50a3c7c8affbb763cfd28a0b41ad7c4",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.12.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0"
-            },
-            "replace": {
-                "roundcube/plugin-installer": "*",
-                "shama/baton": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "1.6.* || ^2.0",
-                "composer/semver": "^1 || ^3",
-                "phpstan/phpstan": "^0.12.55",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.3"
+                "composer/composer": "^1.10.27 || ^2.7",
+                "composer/semver": "^1.7.2 || ^3.4.0",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-phpunit": "^1",
+                "symfony/phpunit-bridge": "^7.1.1",
+                "symfony/process": "^5 || ^6 || ^7"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
+                    "dev-main": "2.x-dev"
+                },
+                "plugin-modifies-install-path": true
             },
             "autoload": {
                 "psr-4": {
@@ -61,7 +59,6 @@
             "description": "A multi-framework Composer library installer",
             "homepage": "https://composer.github.io/installers/",
             "keywords": [
-                "Craft",
                 "Dolibarr",
                 "Eliasis",
                 "Hurad",
@@ -82,7 +79,6 @@
                 "Whmcs",
                 "WolfCMS",
                 "agl",
-                "aimeos",
                 "annotatecms",
                 "attogram",
                 "bitrix",
@@ -91,6 +87,7 @@
                 "cockpit",
                 "codeigniter",
                 "concrete5",
+                "concreteCMS",
                 "croogo",
                 "dokuwiki",
                 "drupal",
@@ -101,7 +98,6 @@
                 "grav",
                 "installer",
                 "itop",
-                "joomla",
                 "known",
                 "kohana",
                 "laravel",
@@ -110,6 +106,7 @@
                 "magento",
                 "majima",
                 "mako",
+                "matomo",
                 "mediawiki",
                 "miaoxing",
                 "modulework",
@@ -129,9 +126,7 @@
                 "silverstripe",
                 "sydes",
                 "sylius",
-                "symfony",
                 "tastyigniter",
-                "typo3",
                 "wordpress",
                 "yawik",
                 "zend",
@@ -139,7 +134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.12.0"
+                "source": "https://github.com/composer/installers/tree/v2.3.0"
             },
             "funding": [
                 {
@@ -155,7 +150,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T08:19:44+00:00"
+            "time": "2024-06-24T20:46:46+00:00"
         },
         {
             "name": "woocommerce/action-scheduler",
@@ -1571,21 +1566,22 @@
         },
         {
             "name": "humanmade/mercator",
-            "version": "1.0.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/Mercator.git",
-                "reference": "21b0e838ff23d24bf023a74d1da42e063553d934"
+                "reference": "5adf68c851be05704e9ae00ce1f864f656c01a95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/Mercator/zipball/21b0e838ff23d24bf023a74d1da42e063553d934",
-                "reference": "21b0e838ff23d24bf023a74d1da42e063553d934",
+                "url": "https://api.github.com/repos/humanmade/Mercator/zipball/5adf68c851be05704e9ae00ce1f864f656c01a95",
+                "reference": "5adf68c851be05704e9ae00ce1f864f656c01a95",
                 "shasum": ""
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
+            "default-branch": true,
             "type": "wordpress-muplugin",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1607,7 +1603,7 @@
                 "issues": "https://github.com/humanmade/Mercator/issues",
                 "source": "https://github.com/humanmade/Mercator/tree/master"
             },
-            "time": "2018-10-30T18:53:20+00:00"
+            "time": "2024-12-06T11:31:05+00:00"
         },
         {
             "name": "johnbillion/query-monitor",
@@ -8719,6 +8715,12 @@
     ],
     "aliases": [
         {
+            "package": "humanmade/mercator",
+            "version": "9999999-dev",
+            "alias": "1.1.0",
+            "alias_normalized": "1.1.0.0"
+        },
+        {
             "package": "phpcompatibility/php-compatibility",
             "version": "dev-develop",
             "alias": "9.99.99",
@@ -8727,6 +8729,7 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "humanmade/mercator": 20,
         "phpcompatibility/php-compatibility": 20
     },
     "prefer-stable": false,
@@ -8739,5 +8742,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Widens composer/installers from ~1.0 to ^1.0 || ^2.0 and bumps humanmade/mercator (require-dev) from ^1.0 to \"dev-master as 1.1.0\" so the lock can actually move to installers v2.

The tagged mercator 1.0.3 (2018) pins composer/installers to ~1.0 and was the only blocker. mercator's master branch (last commit 2024-12-06) loosens that to ~1.0 || ~2.0. mercator is a dev-only dependency used to exercise multisite + domain-mapping in PHPUnit and is not shipped in the release zip.

Lock resolves to composer/installers v2.3.0 and mercator dev-master (5adf68c).

Closes #1821