### PR TITLE
Skip async deletion AS query outside admin

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -757,23 +757,10 @@ class Admin {
 	/**
 	 * Checks if the async deletion process is running.
 	 *
-	 * Short-circuits outside admin (the only callers — Settings::get_fields and
-	 * Settings::get_deletion_warning — render admin UI) and memoises per request,
-	 * since Settings::get_options runs on `init` for every pageload and walks the
-	 * field definition twice in a single request.
-	 *
 	 * @return bool True if the async deletion process is running, false otherwise.
 	 */
 	public static function is_running_async_deletion() {
-		if ( ! is_admin() ) {
-			return false;
-		}
-
-		static $cached = null;
-		if ( null === $cached ) {
-			$cached = as_has_scheduled_action( self::ASYNC_DELETION_ACTION );
-		}
-		return $cached;
+		return as_has_scheduled_action( self::ASYNC_DELETION_ACTION );
 	}
 
 	/**

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -711,10 +711,23 @@ class Admin {
 	/**
 	 * Checks if the async deletion process is running.
 	 *
+	 * Short-circuits outside admin (the only callers — Settings::get_fields and
+	 * Settings::get_deletion_warning — render admin UI) and memoises per request,
+	 * since Settings::get_options runs on `init` for every pageload and walks the
+	 * field definition twice in a single request.
+	 *
 	 * @return bool True if the async deletion process is running, false otherwise.
 	 */
 	public static function is_running_async_deletion() {
-		return as_has_scheduled_action( self::ASYNC_DELETION_ACTION );
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		static $cached = null;
+		if ( null === $cached ) {
+			$cached = as_has_scheduled_action( self::ASYNC_DELETION_ACTION );
+		}
+		return $cached;
 	}
 
 	/**

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -355,22 +355,7 @@ class Settings {
 						'after_field' => esc_html__( 'Enabled', 'stream' ),
 						'default'     => 0,
 					),
-					array(
-						'name'    => 'delete_all_records',
-						'title'   => esc_html__( 'Reset Stream Database', 'stream' ),
-						'type'    => Admin::is_running_async_deletion() ? 'none' : 'link',
-						'href'    => add_query_arg(
-							array(
-								'action'                => 'wp_stream_reset',
-								'wp_stream_nonce_reset' => wp_create_nonce( 'stream_nonce_reset' ),
-							),
-							admin_url( 'admin-ajax.php' )
-						),
-						'class'   => 'warning',
-						'desc'    => esc_html( $this->get_deletion_warning() ),
-						'default' => 0,
-						'sticky'  => 'bottom',
-					),
+					$this->build_delete_all_records_field(),
 					$this->build_clean_orphan_meta_field(),
 				),
 			),
@@ -454,16 +439,53 @@ class Settings {
 	}
 
 	/**
+	 * Build the "Reset Stream Database" settings field definition.
+	 *
+	 * Extracted so the async-deletion running-state check
+	 * ({@see Admin::is_running_async_deletion()}) is evaluated once per render
+	 * instead of once per field property, and only in admin context.
+	 *
+	 * `Settings::__construct` populates `$this->options = $this->get_options()`
+	 * on the `init` hook for every pageload, which walks `get_fields()`. The
+	 * field is only ever rendered in admin, so outside admin the dynamic state
+	 * is irrelevant and the Action Scheduler query is skipped entirely.
+	 *
+	 * @return array
+	 */
+	private function build_delete_all_records_field() {
+		$is_running_deletion = is_admin() ? Admin::is_running_async_deletion() : false;
+
+		return array(
+			'name'    => 'delete_all_records',
+			'title'   => esc_html__( 'Reset Stream Database', 'stream' ),
+			'type'    => $is_running_deletion ? 'none' : 'link',
+			'href'    => add_query_arg(
+				array(
+					'action'                => 'wp_stream_reset',
+					'wp_stream_nonce_reset' => wp_create_nonce( 'stream_nonce_reset' ),
+				),
+				admin_url( 'admin-ajax.php' )
+			),
+			'class'   => 'warning',
+			'desc'    => esc_html( $this->get_deletion_warning( $is_running_deletion ) ),
+			'default' => 0,
+			'sticky'  => 'bottom',
+		);
+	}
+
+	/**
 	 * Build the "Clean Orphaned Meta" settings field definition.
 	 *
 	 * Extracted so the auto-purge running-state check
 	 * ({@see Admin::is_running_auto_purge()}) is evaluated once per render
-	 * instead of once per field property.
+	 * instead of once per field property, and only in admin context — the
+	 * field is never rendered outside admin, so the Action Scheduler query
+	 * is skipped on front-end pageloads.
 	 *
 	 * @return array
 	 */
 	private function build_clean_orphan_meta_field() {
-		$is_running = Admin::is_running_auto_purge();
+		$is_running = is_admin() ? Admin::is_running_auto_purge() : false;
 
 		return array(
 			'name'    => 'clean_orphan_meta',
@@ -626,12 +648,22 @@ class Settings {
 	 * Retrieves the deletion warning message based on the site type
 	 * and whether or not there is currently a process running to delete the tables.
 	 *
+	 * @param bool|null $is_running_deletion Optional pre-computed deletion state.
+	 *                                       Pass to avoid a duplicate Action Scheduler
+	 *                                       query when the caller has already checked.
+	 *                                       Defaults to checking only in admin context.
+	 *                                       Untyped parameter to remain compatible with
+	 *                                       phpcs.xml.dist testVersion=7.0- (nullable
+	 *                                       type declarations require PHP 7.1+).
 	 * @return string The deletion warning message.
 	 */
-	public function get_deletion_warning(): string {
+	public function get_deletion_warning( $is_running_deletion = null ): string {
 
-		// Check if there is an action scheduler event running already deleting things.
-		if ( Admin::is_running_async_deletion() ) {
+		if ( null === $is_running_deletion ) {
+			$is_running_deletion = is_admin() ? Admin::is_running_async_deletion() : false;
+		}
+
+		if ( $is_running_deletion ) {
 
 			$warning = __( 'Currently deleting records. Please be patient, this can take a while.', 'stream' );
 

--- a/tests/phpunit/test-class-admin.php
+++ b/tests/phpunit/test-class-admin.php
@@ -1459,6 +1459,131 @@ class Test_Admin extends WP_StreamTestCase {
 		as_unschedule_all_actions( \WP_Stream\Admin::AUTO_PURGE_BATCH_ACTION );
 	}
 
+	public function test_is_running_async_deletion_reflects_scheduled_state() {
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( \WP_Stream\Admin::ASYNC_DELETION_ACTION );
+		}
+
+		$this->assertFalse(
+			\WP_Stream\Admin::is_running_async_deletion(),
+			'No scheduled action means not running'
+		);
+
+		as_enqueue_async_action(
+			\WP_Stream\Admin::ASYNC_DELETION_ACTION,
+			array(
+				'total'      => 1,
+				'done'       => 0,
+				'last_entry' => 1,
+				'blog_id'    => (int) get_current_blog_id(),
+			)
+		);
+		$this->assertTrue(
+			\WP_Stream\Admin::is_running_async_deletion(),
+			'A pending async-deletion action means running'
+		);
+
+		as_unschedule_all_actions( \WP_Stream\Admin::ASYNC_DELETION_ACTION );
+		$this->assertFalse(
+			\WP_Stream\Admin::is_running_async_deletion(),
+			'After unscheduling: not running'
+		);
+	}
+
+	/**
+	 * Integration test for the "Reset Stream Database" running-state UI swap.
+	 * Asserts that the delete_all_records field flips from type=link to
+	 * type=none and swaps its description when an async-deletion action is
+	 * scheduled. Mirrors test_clean_orphan_meta_field_reflects_running_state.
+	 */
+	public function test_delete_all_records_field_reflects_running_state() {
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( \WP_Stream\Admin::ASYNC_DELETION_ACTION );
+		}
+
+		$find_field = function () {
+			$fields = $this->plugin->settings->get_fields();
+			foreach ( $fields['advanced']['fields'] as $field ) {
+				if ( isset( $field['name'] ) && 'delete_all_records' === $field['name'] ) {
+					return $field;
+				}
+			}
+			return null;
+		};
+
+		// Idle: link visible, warning description.
+		$idle = $find_field();
+		$this->assertNotNull( $idle, 'delete_all_records field must exist on the Advanced tab' );
+		$this->assertSame( 'link', $idle['type'], 'Idle state must render as a link' );
+		$this->assertStringContainsString(
+			'Warning',
+			$idle['desc'],
+			'Idle description must show the deletion warning'
+		);
+
+		// Simulate an active deletion by scheduling the action.
+		as_enqueue_async_action(
+			\WP_Stream\Admin::ASYNC_DELETION_ACTION,
+			array(
+				'total'      => 1,
+				'done'       => 0,
+				'last_entry' => 1,
+				'blog_id'    => (int) get_current_blog_id(),
+			)
+		);
+
+		$active = $find_field();
+		$this->assertNotNull( $active );
+		$this->assertSame(
+			'none',
+			$active['type'],
+			'Active state must hide the link by swapping the field type to none'
+		);
+		$this->assertStringContainsString(
+			'Currently deleting records',
+			$active['desc'],
+			'Active description must communicate that deletion is in progress'
+		);
+
+		as_unschedule_all_actions( \WP_Stream\Admin::ASYNC_DELETION_ACTION );
+	}
+
+	/**
+	 * Verifies that get_deletion_warning() honours the pre-computed deletion
+	 * state passed by build_delete_all_records_field(), avoiding a duplicate
+	 * Action Scheduler query inside a single render.
+	 */
+	public function test_get_deletion_warning_respects_precomputed_state() {
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( \WP_Stream\Admin::ASYNC_DELETION_ACTION );
+		}
+
+		// No deletion scheduled, but caller asserts "running" — message must reflect the argument.
+		$this->assertStringContainsString(
+			'Currently deleting records',
+			$this->plugin->settings->get_deletion_warning( true ),
+			'When caller passes true, message must reflect running deletion regardless of AS state'
+		);
+
+		// Schedule a real action, but caller asserts "not running" — message must reflect the argument.
+		as_enqueue_async_action(
+			\WP_Stream\Admin::ASYNC_DELETION_ACTION,
+			array(
+				'total'      => 1,
+				'done'       => 0,
+				'last_entry' => 1,
+				'blog_id'    => (int) get_current_blog_id(),
+			)
+		);
+		$this->assertStringNotContainsString(
+			'Currently deleting records',
+			$this->plugin->settings->get_deletion_warning( false ),
+			'When caller passes false, message must reflect idle state regardless of AS state'
+		);
+
+		as_unschedule_all_actions( \WP_Stream\Admin::ASYNC_DELETION_ACTION );
+	}
+
 	public function test_register_hooks_auto_purge_action_scheduler_callbacks() {
 		// The Admin instance is constructed by the test bootstrap, so register()
 		// has already run. Just assert the actions are wired up.


### PR DESCRIPTION
> **Note:** This PR was originally authored with AI assistance (Claude Code) and has follow-up commits addressing review feedback. Please review carefully before merging.

## Summary

Fixes #1884.

Stream's settings field definitions embed Action Scheduler "is running?" probes inside their `type` and `desc` properties. Because `Settings::__construct` eagerly walks `get_options()` → `get_defaults()` → `get_fields()` on the `init` hook for **every pageload**, those probes fire on every front-end pageview as well — even though the values are only ever consumed by admin UI.

Two probes are affected:

- `Admin::is_running_async_deletion()` — backs the **Reset Stream Database** field (`delete_all_records`). Calls `as_has_scheduled_action()` twice per render (once for `type`, once for `desc` via `get_deletion_warning()`).
- `Admin::is_running_auto_purge()` — backs the **Clean Orphaned Meta** field (`clean_orphan_meta`). Calls `as_get_scheduled_actions()` up to twice per render (batch worker + reaper hooks).

Together: ~3-4 Action Scheduler queries on every pageview of every Stream-active site, including front-end, regardless of where the request is heading.

### Approach

Move the gate to the UI layer (`Settings`) rather than the probe itself (`Admin`):

1. **`Admin::is_running_async_deletion()` stays a one-liner.** No `is_admin()` gate, no static memo. The probe continues to report the truth in all contexts so future non-admin callers (REST endpoints, CLI scripts, AS workers) get the correct answer.

2. **`Admin::is_running_auto_purge()` is left alone.** It has an existing non-admin caller — the recurring auto-purge callback at `class-admin.php:999` uses it as an overlap guard under Action Scheduler, where `is_admin()` is false. Gating that probe would let parallel auto-purge chains stack against the same rows. A process-static memo is also unsafe under AS workers that process multiple actions per PHP process.

3. **`Settings` gates both probes at the UI boundary.** Extracts `build_delete_all_records_field()` to mirror the existing `build_clean_orphan_meta_field()` pattern. Both helpers check `is_admin()` before calling the AS probe — outside admin, the dynamic state is irrelevant because the field is never rendered.

4. **Within one admin render, the deletion state is computed once.** `get_deletion_warning()` gains an optional `$is_running_deletion` parameter so the field builder can pass its already-computed value and avoid a duplicate AS query.

### Why this shape

The earlier version of this PR added the gate inside `Admin::is_running_async_deletion()` directly. Two issues with that:

- It silently changed the contract of a `public static` method. Any caller outside `Settings` (custom CLI, REST endpoint, anyone hooking the same scheduler) would get a wrong answer in non-admin contexts.
- It didn't extend to the sibling probe `is_running_auto_purge()` (which has the same per-pageload cost) because that probe must keep working outside admin for the overlap guard.

Lifting the gate into the caller layer fixes both at once and keeps the probes correct in every context.

### Before / after

| Context | Before | After |
|---|---|---|
| Front-end pageload | 2 `as_has_scheduled_action` + up to 2 `as_get_scheduled_actions` | **0** |
| Admin pageload | 2 `as_has_scheduled_action` + 1 `as_get_scheduled_actions` (auto-purge already deduped) | 1 + 1 (one probe per field, deduped) |
| Admin-ajax | Same as admin pageload | Same |
| AS worker (overlap guard, `class-admin.php:999`) | 1 `as_get_scheduled_actions` | **1 — unchanged. Semantics preserved.** |

Verified locally on a network-activated multisite dev install via a `SAVEQUERIES`-backed probe:

```
[front-end /]                                                            AS queries: 0
[front-end /wp-login.php]                                                AS queries: 0
[admin     /wp-admin/admin.php?page=wp_stream_settings&tab=advanced]     AS queries: 2 Stream-specific
[admin     /wp-admin/network/admin.php?page=wp_stream_network_settings]  AS queries: 2 Stream-specific
[AS worker /wp-cron.php?doing_wp_cron=…]                                 (unchanged — AS infra)
```

## Test plan

### Automated

- [x] **`tests/phpunit/test-class-admin.php`** — three new PHPUnit tests, pass on both single-site and multisite:
  - `test_is_running_async_deletion_reflects_scheduled_state` — closes a pre-existing coverage gap on the probe itself.
  - `test_delete_all_records_field_reflects_running_state` — integration: field flips `type` (`link` ↔ `none`) and `desc` text based on AS state.
  - `test_get_deletion_warning_respects_precomputed_state` — verifies the new optional parameter on `get_deletion_warning()`.
- [x] Full PHPUnit suite passes locally on both single-site and multisite (361 tests, 0 failures).
- [x] PHPCS clean on changed files (0 errors, 0 warnings).
- [x] Playwright e2e suite passes (14/14 in CI mode).

### Manual

- [x] Front-end pageview produces **zero** `actionscheduler_actions` queries from Stream's paths (verified via mu-plugin probe counting AS queries during `shutdown`).
- [x] Network admin settings screen still renders the "Reset Stream Database" link and warning.
- [x] Settings screen still renders the "Clean Orphaned Meta" link in idle state.
- [x] Per-site settings screen continues to hide `delete_all_records` on network-activated installs (pre-existing `Network::get_network_admin_fields` behavior — unchanged).
- [x] Stream Records page loads with no console errors.

### Known limitations of automated coverage

- The `!is_admin()` short-circuit is not directly asserted by PHPUnit. The WP test suite defines `WP_ADMIN` globally mid-run and PHP constants cannot be undefined, so the `false` branch can't be reliably entered within the same process. The contract is covered by passing the pre-computed value explicitly to `get_deletion_warning()` in `test_get_deletion_warning_respects_precomputed_state`. End-to-end front-end behavior was verified by the manual probe above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
