### PR TITLE
test(phpunit): load Trait_View_Stream_Permission in bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,15 @@ define( 'WP_STREAM_TESTS', true );
 define( 'WP_STREAM_DEV_DEBUG', true );
 define( 'WP_STEAM_TESTDATA', __DIR__ . '/data' );
 
+// Load the shared abilities trait at bootstrap. Production loads it via
+// Abilities::load_abilities() before any class-ability-*.php file is included.
+// PHPUnit's coverage post-processor with processUncoveredFiles="true" walks the
+// <coverage><include> directories directly via include_once, bypassing the
+// plugin's loader, so each ability class hits a fatal on `use
+// Trait_View_Stream_Permission`. Loading the trait here mirrors the production
+// chokepoint without per-file require_once noise.
+require_once dirname( __DIR__ ) . '/abilities/trait-view-stream-permission.php';
+
 // @see https://core.trac.wordpress.org/browser/trunk/tests/phpunit/includes/functions.php
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
## Summary

PHPUnit's coverage post-processor (`processUncoveredFiles="true"` in `phpunit.xml`) walks every file in `<coverage><include>` directly via `include_once` after the test run. It bypasses the plugin's own loader. On runs where the order surfaces the issue (PHP 7.4 in the dev container is reliable; PHP 8.1 has been masking it on CI), each read ability fatals on `use Trait_View_Stream_Permission`:

```
Fatal error: Trait 'WP_Stream\Trait_View_Stream_Permission' not found in abilities/class-ability-get-alerts.php on line 13
```

Tests pass, but the clover.xml emit step crashes and the test target exits non-zero. `make-clover-relative.php` then runs against an incomplete or missing report.

Production loads the trait once via `Abilities::load_abilities()` before any `class-ability-*.php` file is included (centralized in a65b9cf so new abilities do not have to remember per-file `require_once`). The fix mirrors that chokepoint at the test bootstrap.

## What changed

- `tests/bootstrap.php`: `require_once` the trait file before WP test functions load, so it is available before PHPUnit's coverage walker hits any consumer.

## Why this layer

| Option | Why not |
|---|---|
| Per-file `require_once` in each `class-ability-*.php` | Reverts a65b9cf; a new ability could forget the require |
| `<file>abilities/trait-view-stream-permission.php</file>` in `<coverage><include>` | Coverage walker uses alphabetical order, so `trait-` still loads after `class-` consumers |
| Disable `processUncoveredFiles="true"` | Changes coverage reporting semantics; uncovered files stop appearing at 0% |
| Bootstrap require (this PR) | One line, test-only file, no production code touched, no semantics change |

## Verification

```
# Before
$ vendor/bin/phpunit --coverage-text --filter=test_construct
Tests: 1, Assertions: ...  OK
Fatal error: Trait 'WP_Stream\Trait_View_Stream_Permission' not found ...
$ echo $?
255

# After
$ vendor/bin/phpunit --coverage-text --filter=test_construct
Tests: 1, Assertions: ...  OK
... coverage report ...
$ echo $?
0
```

PHPCS clean on `./tests --standard=./tests/phpcs.xml.dist`.

## Release Changelog

- Fix: PHPUnit coverage generation no longer fatals on `Trait_View_Stream_Permission` not found when the post-processor walks the abilities directory.