### PR TITLE
Release 4.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 - Fix unbounded growth of `stream` / `stream_meta` tables: the TTL-based auto-purge now runs via Action Scheduler with batched deletion (default 250,000 rows per batch via the existing `wp_stream_batch_size` filter), resolving database bloat on sites where the previous WP-Cron-driven purge silently failed or timed out on large tables (XWPENG-28, [#1882](https://github.com/xwp/stream/pull/1882)).
 - Fix orphan `stream_meta` rows accumulating across repeated purge cycles: a terminal orphan reaper now runs at the end of every auto-purge chain, healing installs that have residual orphans from historical interrupted purges.
+- Skip Action Scheduler "is running?" probes on front-end pageloads: the `delete_all_records` and `clean_orphan_meta` settings fields no longer issue Action Scheduler queries on every front-end request, eliminating 3-4 unnecessary queries per pageview on every Stream-active site ([#1884](https://github.com/xwp/stream/issues/1884), [#1885](https://github.com/xwp/stream/pull/1885)).
 
 ### Enhancements
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Stream Changelog
 
-## 4.2.0 - TBD
+## 4.2.0 - May 28, 2026
 
 ### New Features
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,14 @@
 # Stream Changelog
 
-## Unreleased
+## 4.2.0 - TBD
+
+### New Features
+
+- Expose Stream abilities via the WordPress MCP Adapter when present, enabling AI tools to query Stream records through the Abilities API (XWPENG-13, [#1859](https://github.com/xwp/stream/pull/1859)).
 
 ### Bug Fixes
 
-- Fix unbounded growth of `stream` / `stream_meta` tables: the TTL-based auto-purge now runs via Action Scheduler with batched deletion (default 250,000 rows per batch via the existing `wp_stream_batch_size` filter), resolving database bloat on sites where the previous WP-Cron-driven purge silently failed or timed out on large tables (XWPENG-28).
+- Fix unbounded growth of `stream` / `stream_meta` tables: the TTL-based auto-purge now runs via Action Scheduler with batched deletion (default 250,000 rows per batch via the existing `wp_stream_batch_size` filter), resolving database bloat on sites where the previous WP-Cron-driven purge silently failed or timed out on large tables (XWPENG-28, [#1882](https://github.com/xwp/stream/pull/1882)).
 - Fix orphan `stream_meta` rows accumulating across repeated purge cycles: a terminal orphan reaper now runs at the end of every auto-purge chain, healing installs that have residual orphans from historical interrupted purges.
 
 ### Enhancements
@@ -12,6 +16,14 @@
 - Add **Clean Orphaned Meta** link under **Settings → Advanced** for one-shot cleanup on already-bloated installs. The link is hidden while the auto-purge chain is running and reappears once the chain drains.
 - Replace the legacy `wp_stream_auto_purge` WP-Cron event with a recurring Action Scheduler action. Run history and failures are now visible under **Tools → Scheduled Actions**.
 - Auto-purge consults the existing `wp_stream_is_large_records_table` filter (default threshold: >1M rows) so small tables get a single inline DELETE while bloated tables go through the batched chain — same knob as the manual reset path.
+
+### Development
+
+- Add HTTPS to the local dev environment via mkcert and an Apache SSL vhost; force HTTPS across local dev and tests.
+- Add Playwright E2E job to CI; harden specs against activation races and add jQuery-dependent admin UI smoke spec (in [#1873](https://github.com/xwp/stream/pull/1873), [#1874](https://github.com/xwp/stream/pull/1874)).
+- Update Node.js to v24 (in [#1867](https://github.com/xwp/stream/pull/1867), [#1883](https://github.com/xwp/stream/pull/1883)) and jQuery to v4 (in [#1834](https://github.com/xwp/stream/pull/1834)).
+- Switch dev dependencies from WPackagist to WP Packages (in [#1858](https://github.com/xwp/stream/pull/1858)).
+- Numerous dependency updates: `composer/composer`, `phpunit/phpunit`, `@playwright/test`, `@wordpress/scripts`, `@wordpress/e2e-test-utils-playwright`, `axios`, `tar-fs`, `http-proxy-middleware`, `copy-webpack-plugin`, `npm-run-all2`, `eslint-plugin-react-hooks`, `uuid` → native `crypto.randomUUID()`.
 
 ### Notes
 

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -20,7 +20,7 @@ class Plugin {
 	 *
 	 * @const string
 	 */
-	const VERSION = '4.1.2';
+	const VERSION = '4.2.0';
 
 	/**
 	 * WP-CLI command

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.6
 Tested up to: 6.9
-Stable tag: 4.1.2
+Stable tag: 4.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,10 @@ Use only `$_SERVER['REMOTE_ADDR']` as the client IP address for event logs witho
 
 
 == Changelog ==
+
+= 4.2.0 - TBD =
+
+See: [https://github.com/xwp/stream/blob/develop/changelog.md#420---tbd](https://github.com/xwp/stream/blob/develop/changelog.md#420---tbd)
 
 = 4.1.2 - February 19, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,9 +134,9 @@ Use only `$_SERVER['REMOTE_ADDR']` as the client IP address for event logs witho
 
 == Changelog ==
 
-= 4.2.0 - TBD =
+= 4.2.0 - May 28, 2026 =
 
-See: [https://github.com/xwp/stream/blob/develop/changelog.md#420---tbd](https://github.com/xwp/stream/blob/develop/changelog.md#420---tbd)
+See: [https://github.com/xwp/stream/blob/develop/changelog.md#420---may-28-2026](https://github.com/xwp/stream/blob/develop/changelog.md#420---may-28-2026)
 
 = 4.1.2 - February 19, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.6
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 4.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/stream.php
+++ b/stream.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stream
  * Plugin URI: https://xwp.co/work/stream/
  * Description: Stream tracks logged-in user activity so you can monitor every change made on your WordPress site in beautifully organized detail. All activity is organized by context, action and IP address for easy filtering. Developers can extend Stream with custom connectors to log any kind of action.
- * Version: 4.1.2
+ * Version: 4.2.0
  * Author: XWP
  * Author URI: https://xwp.co
  * License: GPLv2+


### PR DESCRIPTION
## Summary

Prepares the 4.2.0 release off `develop`. Version bumped in `stream.php`, `Plugin::VERSION`, and `readme.txt` Stable tag; changelog `Unreleased` promoted to `4.2.0` with notable items added.

## Highlights since 4.1.2

### New Features
- Expose Stream abilities via the WordPress MCP Adapter (XWPENG-13, #1859).

### Bug Fixes
- Migrate auto-purge to Action Scheduler with batched deletion to fix unbounded `stream` / `stream_meta` growth (XWPENG-28, #1882).
- Terminal orphan reaper at the end of every auto-purge chain.
- Skip Action Scheduler "is running?" probes on front-end pageloads: settings field definitions no longer issue AS queries on every pageview (#1884, #1885).

### Enhancements
- **Clean Orphaned Meta** link under **Settings → Advanced**.
- Recurring Action Scheduler action replaces the legacy `wp_stream_auto_purge` WP-Cron event; run history visible under **Tools → Scheduled Actions**.
- Small-table fast path via `wp_stream_is_large_records_table` filter.

### Development
- HTTPS in local dev env via mkcert + Apache SSL vhost.
- Playwright E2E job added to CI; specs hardened.
- Node.js v24, jQuery v4, dev deps migrated from WPackagist to WP Packages.
- Wide dependency refresh (composer, phpunit, playwright, wp scripts, axios, etc.).

## Pre-merge checklist

- [x] CI green on this branch (lint + PHPUnit single + multisite + Playwright E2E).
- [x] `npm run build` produces clean `build/` output.
- [x] Update changelog date from `TBD` → final release date before tagging `v4.2.0`.
- [ ] Cut `v4.2.0-rc.1` as a GitHub pre-release targeting `release/v4.2.0` and verify WP.org dry-run + ZIP asset.
- [ ] Smoke-test the RC ZIP on a clean WP install (single + multisite).

## Release flow (per contributing.md)

1. Merge this PR into `develop` (or skip the PR — branch alone is enough to cut RCs).
2. Cut pre-release `v4.2.0-rc.N` from `release/v4.2.0`; fix issues on this branch and repeat.
3. When ready, cut release `v4.2.0` from this branch.
4. Merge `release/v4.2.0` → `master`, then `master` → `develop`.

## Notes

- `readme.txt` previously had `4.1.2 - February 19, 2026`; preserved as-is.
- Changelog date is `TBD` pending the actual release day.
- #1885 was merged into `develop` after this branch was first cut and has been merged forward via `7614437d` + `a8fcd0ec`.
