### PR TITLE
fix(ci): correct DIST_BRANCH on release events for stream-dist deploy

### DIFF
--- a/.github/workflows/deploy-to-stream-dist.yml
+++ b/.github/workflows/deploy-to-stream-dist.yml
@@ -64,9 +64,20 @@ jobs:
           WORKING_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
           SRC_DIR="$ROOT_DIR/source"
           DIST_DIR="$ROOT_DIR/dist"
-          DIST_BRANCH="${GITHUB_REF#refs/heads/}"
-          DIST_TAG="${GITHUB_REF#refs/tags/}"
           COMMIT_MESSAGE="$(git log -1 --oneline)"
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # On a release event, GITHUB_REF is refs/tags/<tag>. Push the dist
+            # commit to the branch the release targets (e.g. master) and create
+            # the tag on top of it.
+            DIST_BRANCH="${{ github.event.release.target_commitish }}"
+            DIST_TAG="${GITHUB_REF#refs/tags/}"
+          else
+            # On a push event, GITHUB_REF is refs/heads/<branch>. Mirror the
+            # branch to dist without tagging.
+            DIST_BRANCH="${GITHUB_REF#refs/heads/}"
+            DIST_TAG=""
+          fi
 
           echo "ROOT_DIR=$ROOT_DIR" >> $GITHUB_ENV
           echo "WORKING_BRANCH=$WORKING_BRANCH" >> $GITHUB_ENV
@@ -121,7 +132,7 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "Tagging a release: $DIST_TAG"
             git tag --force "$DIST_TAG"
-            git push --force --tags origin "$DIST_BRANCH"
+            git push --force origin "$DIST_BRANCH" "refs/tags/$DIST_TAG"
           else
             git push --force origin "$DIST_BRANCH"
           fi


### PR DESCRIPTION
Fixes the stream-dist deploy workflow failing on release events with:

```
error: src refspec refs/tags/v4.2.0 matches more than one
error: failed to push some refs to 'github.com:xwp/stream-dist.git'
```

## Root cause

On a release event, `GITHUB_REF` is `refs/tags/<tag>`. The previous setup step did:

```sh
DIST_BRANCH="${GITHUB_REF#refs/heads/}"   # strip prefix that isn't there
DIST_TAG="${GITHUB_REF#refs/tags/}"
```

The `refs/heads/` prefix strip is a no-op for tag refs, so `DIST_BRANCH` ended up as the literal string `refs/tags/v4.2.0`. The later `git checkout -B "$DIST_BRANCH"` then created a branch literally named `refs/tags/v4.2.0` alongside the new tag of the same short name, making `git push --tags origin refs/tags/v4.2.0` ambiguous (matched both the branch and the tag).

## Fix

Branch on `github.event_name` to derive `DIST_BRANCH` correctly:

- On `release` events: pull the branch from `github.event.release.target_commitish` (typically `master`) and the tag from the ref.
- On `push` events: keep the previous behaviour, derive the branch from `refs/heads/` and skip tagging.

Also tighten the release push to explicitly push just the target branch and the new tag instead of relying on `--tags`, which would push every local tag the runner happens to have.

## Why this is a new failure

The `release:` trigger on this workflow was re-added in #1853 (2026-04-02). v4.2.0-rc.1 was the first release event to actually exercise this code path. The bug itself dates back to the September 2024 workflow rewrite and was dormant until then.

## Verified failure runs

- [runs/26573649458](https://github.com/xwp/stream/actions/runs/26573649458) (v4.2.0)
- [runs/26493589602](https://github.com/xwp/stream/actions/runs/26493589602) (v4.2.0-rc.1)

## Follow-up

The `v4.2.0` tag on `xwp/stream-dist` is missing as a result of this failure and will need to be created manually (the dist branch itself was updated successfully by the prior `push`-to-`master` run, so only the tag is missing).

## Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable. (N/A: workflow-only fix.)
- [ ] I have tested the changes in the local development environment (see `contributing.md`). (N/A: cannot exercise release-event workflow locally; will validate on next release.)
- [ ] I have added phpunit tests. (N/A: workflow change.)
