### PR TITLE
chore(renovate): group @wordpress/* updates and run npm dedupe

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,15 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "monorepo:wordpress"
   ],
   "enabledManagers": [
     "npm"
   ],
   "rangeStrategy": "bump",
+  "postUpdateOptions": [
+    "npmDedupe"
+  ],
   "packageRules": [
     {
       "updateTypes": [


### PR DESCRIPTION
Refs #1891.

Renovate cannot regenerate `package-lock.json` when `@wordpress/scripts` crosses a React major because other `@wordpress/*` transitives stay pinned to the older React. Grouping the WordPress monorepo updates and running `npm dedupe` after the install lets the resolver pull compatible transitive versions in the same PR.

- Add `monorepo:wordpress` preset to group all `@wordpress/*` direct deps into one PR
- Add `postUpdateOptions: ["npmDedupe"]` so Renovate runs `npm dedupe` after each update

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Group WordPress monorepo updates and dedupe lockfile in Renovate to avoid resolver conflicts.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
