### PR TITLE
Fix inverted isset check silently ignoring user search input in get_u…

### DIFF
--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -112,7 +112,7 @@ class Settings {
 		$search = '';
 		$input  = wp_stream_filter_input( INPUT_POST, 'find' );
 
-		if ( ! isset( $input['term'] ) ) {
+		if ( isset( $input['term'] ) ) {
 			$search = wp_unslash( trim( $input['term'] ) );
 		}
 


### PR DESCRIPTION
Hey folks,

The get_users() AJAX handler in class-settings.php has an inverted isset check — if ( ! isset( $input['term'] ) ) means the search term is only read when the key is absent, so every search on the Exclude Settings page ignores what the admin typed and returns the default unfiltered list. Removing the ! fixes it. The get_ips() method in the same file already uses the correct (non-inverted) pattern, which is what pointed me to this.

(full disclosure, I used AI help with the testing and tweaks - Christopher)



The guard was '! isset( $input[term] )' which assigned the search term only when the key was absent. Any typed query was ignored and the AJAX handler always returned the default unfiltered user list.

Removing the ! makes the check read correctly: assign the search term when it is present. The get_ips() method in the same class already uses the correct (non-inverted) pattern.

Fixes #000.

Describe your approach and how it fixes the issue.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
